### PR TITLE
chore(trading): always capture trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 *.pyc
 .pytest_cache
 traces/
+.DS_Store

--- a/conftest.py
+++ b/conftest.py
@@ -55,13 +55,7 @@ def page_with_trace(vega, request, browser: Browser):
         with context.new_page() as page:
             yield page
         trace_path = os.path.join("traces", request.node.name + "trace.zip")
-        try:
-            if request.node.rep_call.failed:
-                context.tracing.stop(path=trace_path)
-        except AttributeError:
-            context.tracing.stop(path=trace_path)
-        else:
-            context.tracing.stop()
+        context.tracing.stop(path=trace_path)
 
 
 # Setup window._env_ variables. Note: This is named `page` so that the `page` argument


### PR DESCRIPTION
We are seeing a few scenarios where our tests are erroring and we don't get a trace.

This is because we are only capturing traces on failed tests.

This pr will mean we always get traces.