### PR TITLE
chore: use bigger runner in console-test job

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     timeout-minutes: 20
-    runs-on: 4-cores
+    runs-on: 8-cores
     steps:
     - uses: actions/checkout@v3
     #----------------------------------------------

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: 4-cores
     steps:
     - uses: actions/checkout@v3
     #----------------------------------------------

--- a/tests/trade_match/test_trade_match.py
+++ b/tests/trade_match/test_trade_match.py
@@ -44,14 +44,17 @@ def test_trade_match_table(opening_auction_market: str, vega: VegaService, page:
     # Positions
     page.get_by_test_id("Positions").click()
     expect(page.get_by_test_id("tab-positions").locator(row_locator)).to_contain_text(
-        "BTC:DAI_2023" + "426.00" + "-4" + "-"
-    )
-
-    # Skipping Marigin check because of CI issues
-    # + "237,007.10401 - 237,231.92254"
-
-    expect(page.get_by_test_id("tab-positions").locator(row_locator)).to_contain_text(
-        "tDAI" + "106.50" + "0.0" + "43.94338" + "1.50" + "0.00",
+        "BTC:DAI_2023"
+        + "426.00"
+        + "-4"
+        + "-"
+        + "237,007.10401 - 237,231.92254"
+        + "tDAI"
+        + "106.50"
+        + "0.0"
+        + "43.94338"
+        + "1.50"
+        + "0.00",
     )
 
     # Open


### PR DESCRIPTION
We have 8-cores ubuntu runner available which provides us with better performance and removes (in most part) differences between local & CI environment.