### PR TITLE
feat(trading): run on pr marks added

### DIFF
--- a/tests/deal_ticket/test_fees_margin_estimations.py
+++ b/tests/deal_ticket/test_fees_margin_estimations.py
@@ -16,7 +16,7 @@ margin_required = "deal-ticket-fee-margin-required"
 item_value = "item-value"
 market_trading_mode = "market-trading-mode"
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_margin_and_fees_estimations(continuous_market, vega: VegaService, page: Page):
     # setup continuous trading market with one user buy trade

--- a/tests/deal_ticket/test_fees_margin_estimations.py
+++ b/tests/deal_ticket/test_fees_margin_estimations.py
@@ -16,7 +16,7 @@ margin_required = "deal-ticket-fee-margin-required"
 item_value = "item-value"
 market_trading_mode = "market-trading-mode"
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_margin_and_fees_estimations(continuous_market, vega: VegaService, page: Page):
     # setup continuous trading market with one user buy trade

--- a/tests/deal_ticket/test_stop_order.py
+++ b/tests/deal_ticket/test_stop_order.py
@@ -52,7 +52,7 @@ def create_position(vega: VegaService, market_id):
     vega.forward("10s")
     vega.wait_for_total_catchup
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_stop_order_form_error_validation(continuous_market, page: Page):
 
@@ -72,7 +72,7 @@ def test_stop_order_form_error_validation(continuous_market, page: Page):
     page.get_by_test_id(order_price).fill("0.0000001")
     expect(page.get_by_test_id("stop-order-error-message-price")).to_have_text("Price cannot be lower than 0.00001")
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: Page):
 
@@ -103,7 +103,7 @@ def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: 
     expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("FOK")
     expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_market_order_triggered(continuous_market, vega: VegaService, page: Page):
     # 7002-SORD-071
@@ -152,7 +152,7 @@ def test_submit_stop_market_order_triggered(continuous_market, vega: VegaService
     expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("FOK")
     expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_limit_order_pending(continuous_market, vega: VegaService, page: Page):
     # 7002-SORD-071
@@ -199,7 +199,7 @@ def test_submit_stop_limit_order_pending(continuous_market, vega: VegaService, p
     expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("IOC")
     expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_limit_order_cancel(continuous_market, vega: VegaService, page: Page):
 

--- a/tests/deal_ticket/test_stop_order.py
+++ b/tests/deal_ticket/test_stop_order.py
@@ -52,6 +52,7 @@ def create_position(vega: VegaService, market_id):
     vega.forward("10s")
     vega.wait_for_total_catchup
 
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_stop_order_form_error_validation(continuous_market, page: Page):
 
@@ -71,6 +72,7 @@ def test_stop_order_form_error_validation(continuous_market, page: Page):
     page.get_by_test_id(order_price).fill("0.0000001")
     expect(page.get_by_test_id("stop-order-error-message-price")).to_have_text("Price cannot be lower than 0.00001")
 
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: Page):
 
@@ -101,7 +103,7 @@ def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: 
     expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("FOK")
     expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_market_order_triggered(continuous_market, vega: VegaService, page: Page):
     # 7002-SORD-071
@@ -150,6 +152,7 @@ def test_submit_stop_market_order_triggered(continuous_market, vega: VegaService
     expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("FOK")
     expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
 
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_limit_order_pending(continuous_market, vega: VegaService, page: Page):
     # 7002-SORD-071
@@ -196,6 +199,7 @@ def test_submit_stop_limit_order_pending(continuous_market, vega: VegaService, p
     expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("IOC")
     expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
 
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_submit_stop_limit_order_cancel(continuous_market, vega: VegaService, page: Page):
 
@@ -229,7 +233,8 @@ def test_submit_stop_limit_order_cancel(continuous_market, vega: VegaService, pa
     page.get_by_test_id(close_toast).click()
 
     expect((page.get_by_role(row_table).locator('[col-id="status"]')).nth(1)).to_have_text("Cancelled")
-    
+
+
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_stop_market_order_form_validation(continuous_market, vega: VegaService, page: Page):
 

--- a/tests/iceberg_orders/test_iceberg_orders.py
+++ b/tests/iceberg_orders/test_iceberg_orders.py
@@ -20,7 +20,7 @@ def hover_and_assert_tooltip(page, element_text):
     element.hover()
     expect(page.get_by_role("tooltip")).to_be_visible()
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_iceberg_submit(continuous_market,vega: VegaService,   page: Page):
     page.goto(f"/#/markets/{continuous_market}")
@@ -66,7 +66,7 @@ def test_iceberg_validations(continuous_market,  page: Page):
     expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_be_visible()
     expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_have_text('Minimum visible size cannot be lower than 1')
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_iceberg_open_order(continuous_market,vega: VegaService, page: Page):
      page.goto(f"/#/markets/{continuous_market}")

--- a/tests/iceberg_orders/test_iceberg_orders.py
+++ b/tests/iceberg_orders/test_iceberg_orders.py
@@ -20,6 +20,7 @@ def hover_and_assert_tooltip(page, element_text):
     element.hover()
     expect(page.get_by_role("tooltip")).to_be_visible()
 
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_iceberg_submit(continuous_market,vega: VegaService,   page: Page):
     page.goto(f"/#/markets/{continuous_market}")
@@ -65,7 +66,7 @@ def test_iceberg_validations(continuous_market,  page: Page):
     expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_be_visible()
     expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_have_text('Minimum visible size cannot be lower than 1')
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_iceberg_open_order(continuous_market,vega: VegaService, page: Page):
      page.goto(f"/#/markets/{continuous_market}")

--- a/tests/market/test_market.py
+++ b/tests/market/test_market.py
@@ -34,7 +34,7 @@ initial_volume: float = 1
 initial_spread: float = 0.1
 market_name = "BTC:DAI_2023"
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("simple_market", "risk_accepted")
 def test_price_monitoring(simple_market, vega: VegaService, page: Page):    
     page.goto(f"/#/markets/all")

--- a/tests/market/test_market.py
+++ b/tests/market/test_market.py
@@ -34,7 +34,7 @@ initial_volume: float = 1
 initial_spread: float = 0.1
 market_name = "BTC:DAI_2023"
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("simple_market", "risk_accepted")
 def test_price_monitoring(simple_market, vega: VegaService, page: Page):    
     page.goto(f"/#/markets/all")

--- a/tests/market_lifecycle/test_market_lifecycle.py
+++ b/tests/market_lifecycle/test_market_lifecycle.py
@@ -16,7 +16,7 @@ TERMINATE_WALLET = WalletConfig("FJMKnwfZdd48C8NqvYrG", "bY3DxwtsCstMIIZdNpKs")
 
 wallets = [MM_WALLET, MM_WALLET2, TERMINATE_WALLET]
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("proposed_market", "risk_accepted")
 def test_market_lifecycle(proposed_market, vega: VegaService, page: Page):
     trading_mode = page.get_by_test_id("market-trading-mode").get_by_test_id(

--- a/tests/market_lifecycle/test_market_lifecycle.py
+++ b/tests/market_lifecycle/test_market_lifecycle.py
@@ -16,7 +16,7 @@ TERMINATE_WALLET = WalletConfig("FJMKnwfZdd48C8NqvYrG", "bY3DxwtsCstMIIZdNpKs")
 
 wallets = [MM_WALLET, MM_WALLET2, TERMINATE_WALLET]
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("proposed_market", "risk_accepted")
 def test_market_lifecycle(proposed_market, vega: VegaService, page: Page):
     trading_mode = page.get_by_test_id("market-trading-mode").get_by_test_id(

--- a/tests/order_details/test_order_details.py
+++ b/tests/order_details/test_order_details.py
@@ -30,7 +30,8 @@ def verify_order_value(page: Page, test_id: str, expected_text: str, is_regex: b
         assert re.match(expected_text, actual_text), f"Expected {expected_text}, but got {actual_text}"
     else:
         expect(element).to_have_text(expected_text)
-
+        
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_order_details_are_correctly_displayed(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")

--- a/tests/order_details/test_order_details.py
+++ b/tests/order_details/test_order_details.py
@@ -31,7 +31,7 @@ def verify_order_value(page: Page, test_id: str, expected_text: str, is_regex: b
     else:
         expect(element).to_have_text(expected_text)
         
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_order_details_are_correctly_displayed(continuous_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/{continuous_market}")

--- a/tests/order_match/test_order_match.py
+++ b/tests/order_match/test_order_match.py
@@ -76,7 +76,7 @@ def submit_order(vega, wallet_name, market_id, side, volume, price):
         price=price,
     )
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("opening_auction_market", "auth")
 def test_limit_order_trade_open_order(
     opening_auction_market, vega: VegaService, page: Page
@@ -106,7 +106,7 @@ def test_limit_order_trade_open_order(
     print("Assert Open orders:")
     verify_data_grid(page, "Open", expected_open_order)
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_limit_order_trade_open_position(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")

--- a/tests/order_match/test_order_match.py
+++ b/tests/order_match/test_order_match.py
@@ -76,7 +76,7 @@ def submit_order(vega, wallet_name, market_id, side, volume, price):
         price=price,
     )
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("opening_auction_market", "auth")
 def test_limit_order_trade_open_order(
     opening_auction_market, vega: VegaService, page: Page
@@ -106,7 +106,7 @@ def test_limit_order_trade_open_order(
     print("Assert Open orders:")
     verify_data_grid(page, "Open", expected_open_order)
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_limit_order_trade_open_position(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")

--- a/tests/pnl/test_pnl.py
+++ b/tests/pnl/test_pnl.py
@@ -73,7 +73,7 @@ def wait_for_service(url, timeout=60):
             if time.time() - start_time > timeout:
                 raise TimeoutError(f"Timed out waiting for service at {url}")
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_loss_portfolio(continuous_market, vega:VegaService, page: Page):    
     page.set_viewport_size({"width":1748, "height":977})
@@ -100,7 +100,7 @@ def test_pnl_loss_portfolio(continuous_market, vega:VegaService, page: Page):
     check_pnl_color_value(realised_pnl, 'rgb(236, 0, 60)', '-8.00')
     check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_profit_portfolio(continuous_market, vega:VegaService, page: Page):
     page.set_viewport_size({"width":1748, "height":977})
@@ -126,7 +126,8 @@ def test_pnl_profit_portfolio(continuous_market, vega:VegaService, page: Page):
     wait_for_graphql_response(page, 'EstimatePosition')
     check_pnl_color_value(realised_pnl, 'rgb(1, 145, 75)', '8.00')
     check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
- 
+
+@pytest.mark.test_on_pr 
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_neutral_portfolio(continuous_market, vega:VegaService, page: Page):
     page.set_viewport_size({"width":1748, "height":977})
@@ -191,6 +192,7 @@ def test_pnl_profit_trading(continuous_market, vega:VegaService, page: Page):
     check_pnl_color_value(realised_pnl, 'rgb(1, 145, 75)', '8.00')
     check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
 
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_neutral_trading(continuous_market, vega:VegaService, page: Page):
     page.set_viewport_size({"width":1748, "height":977})

--- a/tests/pnl/test_pnl.py
+++ b/tests/pnl/test_pnl.py
@@ -73,7 +73,7 @@ def wait_for_service(url, timeout=60):
             if time.time() - start_time > timeout:
                 raise TimeoutError(f"Timed out waiting for service at {url}")
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_loss_portfolio(continuous_market, vega:VegaService, page: Page):    
     page.set_viewport_size({"width":1748, "height":977})
@@ -100,7 +100,7 @@ def test_pnl_loss_portfolio(continuous_market, vega:VegaService, page: Page):
     check_pnl_color_value(realised_pnl, 'rgb(236, 0, 60)', '-8.00')
     check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_profit_portfolio(continuous_market, vega:VegaService, page: Page):
     page.set_viewport_size({"width":1748, "height":977})
@@ -127,7 +127,7 @@ def test_pnl_profit_portfolio(continuous_market, vega:VegaService, page: Page):
     check_pnl_color_value(realised_pnl, 'rgb(1, 145, 75)', '8.00')
     check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
 
-@pytest.mark.test_on_pr 
+@pytest.mark.critical 
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_neutral_portfolio(continuous_market, vega:VegaService, page: Page):
     page.set_viewport_size({"width":1748, "height":977})
@@ -192,7 +192,7 @@ def test_pnl_profit_trading(continuous_market, vega:VegaService, page: Page):
     check_pnl_color_value(realised_pnl, 'rgb(1, 145, 75)', '8.00')
     check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_pnl_neutral_trading(continuous_market, vega:VegaService, page: Page):
     page.set_viewport_size({"width":1748, "height":977})

--- a/tests/trade_history/test_trade_history.py
+++ b/tests/trade_history/test_trade_history.py
@@ -61,7 +61,7 @@ def wait_for_graphql_response(page, query_name, timeout=5000):
     # Unregister the route handler
     page.unroute("**", handle_response)
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_limit_order_new_trade_top_of_list(continuous_market, vega, page):
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 110)

--- a/tests/trade_history/test_trade_history.py
+++ b/tests/trade_history/test_trade_history.py
@@ -61,7 +61,7 @@ def wait_for_graphql_response(page, query_name, timeout=5000):
     # Unregister the route handler
     page.unroute("**", handle_response)
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("continuous_market", "auth")
 def test_limit_order_new_trade_top_of_list(continuous_market, vega, page):
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 110)

--- a/tests/trade_match/test_trade_match.py
+++ b/tests/trade_match/test_trade_match.py
@@ -4,7 +4,7 @@ from vega_sim.service import VegaService
 
 from actions.vega import submit_multiple_orders
 
-@pytest.mark.test_on_pr
+@pytest.mark.critical
 @pytest.mark.usefixtures("opening_auction_market", "auth")
 def test_trade_match_table(opening_auction_market: str, vega: VegaService, page: Page):
     row_locator = ".ag-center-cols-container .ag-row"

--- a/tests/trade_match/test_trade_match.py
+++ b/tests/trade_match/test_trade_match.py
@@ -4,7 +4,7 @@ from vega_sim.service import VegaService
 
 from actions.vega import submit_multiple_orders
 
-
+@pytest.mark.test_on_pr
 @pytest.mark.usefixtures("opening_auction_market", "auth")
 def test_trade_match_table(opening_auction_market: str, vega: VegaService, page: Page):
     row_locator = ".ag-center-cols-container .ag-row"


### PR DESCRIPTION
This pr is just to add the marks rather than actually filter the runs on pr.

i think for now it makes sense to run all tests within console-test.

but update the monorepo pr to only run these marks.

Please do look at the tests and let me know if marks should be added or removed.