### PR TITLE
chore: provide logic to create vega and page fixtures with various scope

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,7 +53,7 @@ jobs:
     #  ----- run tests. -----
     #----------------------------------------------
     - name: Run tests
-      run:  poetry run pytest -s --numprocesses auto
+      run:  poetry run pytest -s --numprocesses auto --dist loadfile
     #----------------------------------------------
     #  -----  upload traces  -----
     #----------------------------------------------

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
   "[python]": {
-    "editor.defaultFormatter": "ms-python.python"
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
   },
-  "python.formatting.provider": "none",
-  "python.testing.pytestArgs": [
+    "python.testing.pytestArgs": [
     "tests"
   ],
   "python.testing.unittestEnabled": false,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ poetry run pytest -k "order_match" -s
 
 ## Running Tests in Parallel
 
-If you want to run tests in parallel, use the --numprocesses auto option:
+If you want to run tests in parallel, use the --numprocesses auto option. --dist loadfile makes sure that there are no multiple runners assigned to single test file:
 ```bash
-poetry run pytest -s --headed --numprocesses auto
+poetry run pytest -s --headed --numprocesses auto --dist loadfile
 ```

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import json
 import requests
 import time
 
+from contextlib import contextmanager
 from vega_sim.null_service import VegaServiceNull
 from playwright.sync_api import Browser, Page
 from config import container_name
@@ -18,8 +19,8 @@ docker_client = docker.from_env()
 
 
 # Start VegaServiceNull and start up docker container for website
-@pytest.fixture(scope="function", autouse=True)
-def vega():
+@contextmanager
+def init_vega():
     print("\nStarting VegaServiceNull")
     with VegaServiceNull(
         run_with_console=False,
@@ -29,74 +30,80 @@ def vega():
         store_transactions=True,
         transactions_per_block=1000,
     ) as vega:
-        # docker setup
-        container = docker_client.containers.run(
-            container_name, detach=True, ports={"80/tcp": vega.console_port}
-        )
-        print(f"Container {container.id} started")
-
-        yield vega
-
         try:
-            container.stop()
-            print(f"Container '{container_name}' stopped successfully.")
-        except docker.errors.NotFound:
-            print(f"Container '{container_name}' not found.")
+            container = docker_client.containers.run(
+                container_name, detach=True, ports={"80/tcp": vega.console_port}
+            )
+            # docker setup
+            print(f"Container {container.id} started")
+            yield vega
         except docker.errors.APIError as e:
-            print(f"An error occurred while stopping the container: {e}")
+            print(f"Container {container.id} failed")
+            print(e)
+            raise e
+        finally:
+            print(f"Stopping container {container.id}")
+            container.stop()
 
-            # Capture traces on tests
 
-
-@pytest.fixture(scope="function", autouse=True)
-def page_with_trace(vega, request, browser: Browser):
+@contextmanager
+def init_page(vega: VegaServiceNull, browser: Browser, request: pytest.FixtureRequest):
     with browser.new_context(
         viewport={"width": 1920, "height": 1080},
         base_url=f"http://localhost:{vega.console_port}",
     ) as context:
         context.tracing.start(screenshots=True, snapshots=True, sources=True)
         with context.new_page() as page:
-            yield page
-        trace_path = os.path.join("traces", request.node.name + "trace.zip")
-        context.tracing.stop(path=trace_path)
+            try:
+                # Wait for the console to be up and running before any tests are run
+                attempts = 0
+                while attempts < 100:
+                    try:
+                        code = requests.get(
+                            f"http://localhost:{vega.console_port}/"
+                        ).status_code
+                        if code == 200:
+                            break
+                    except requests.exceptions.ConnectionError as e:
+                        attempts += 1
+                        if attempts < 100:
+                            time.sleep(0.1)
+                            continue
+                        else:
+                            raise e
+
+                # Set window._env_ so built docker image data uses datanode from vega market sim
+                env = json.dumps(
+                    {
+                        "VEGA_URL": f"http://localhost:{vega.data_node_rest_port}/graphql",
+                        "VEGA_WALLET_URL": f"http://localhost:{vega.wallet_port}",
+                    }
+                )
+                window_env = f"window._env_ = Object.assign({{}}, window._env_, {env})"
+                page.add_init_script(script=window_env)
+                yield page
+            finally:
+                trace_path = os.path.join("traces", request.node.name + "trace.zip")
+                context.tracing.stop(path=trace_path)
 
 
-# Setup window._env_ variables. Note: This is named `page` so that the `page` argument
-# tests can be used normally.
-@pytest.fixture(scope="function", autouse=True)
-def page(vega: VegaServiceNull, page_with_trace: Page):
-    # Set window._env_ so built docker image data uses datanode from vega market sim
-    env = json.dumps(
-        {
-            "VEGA_URL": f"http://localhost:{vega.data_node_rest_port}/graphql",
-            "VEGA_WALLET_URL": f"http://localhost:{vega.wallet_port}",
-        }
-    )
-    window_env = f"window._env_ = Object.assign({{}}, window._env_, {env})"
-    page_with_trace.add_init_script(script=window_env)
+# default vega & page fixtures with function scope (refreshed at each test) that can be used in tests
+# separate fixtures may be defined in tests if we prefere different scope
+@pytest.fixture
+def vega():
+    with init_vega() as vega:
+        yield vega
 
-    # Wait for the console to be up and running before any tests are run
-    attempts = 0
-    while attempts < 100:
-        try:
-            code = requests.get(f"http://localhost:{vega.console_port}/").status_code
-            if code == 200:
-                break
-        except requests.exceptions.ConnectionError as e:
-            attempts += 1
-            if attempts < 100:
-                time.sleep(0.1)
-                continue
-            else:
-                raise e
 
-    # Just pass on the main page object
-    return page_with_trace
+@pytest.fixture
+def page(vega, browser, request):
+    with init_page(vega, browser, request) as page:
+        yield page
 
 
 # Set auth token so eager connection for MarketSim wallet is successful
 @pytest.fixture(scope="function")
-def auth(vega, page_with_trace):
+def auth(vega: VegaServiceNull, page: Page):
     DEFAULT_WALLET_NAME = "MarketSim"  # This is the default wallet name within VegaServiceNull and CANNOT be changed
 
     # Calling get_keypairs will internally call _load_tokens for the given wallet
@@ -121,7 +128,7 @@ def auth(vega, page_with_trace):
         "localStorage.setItem('vega_risk_accepted', 'true');",
     ]
     script = "".join(storage_javascript)
-    page_with_trace.add_init_script(script)
+    page.add_init_script(script)
 
     return {
         "wallet": DEFAULT_WALLET_NAME,
@@ -132,10 +139,9 @@ def auth(vega, page_with_trace):
 
 # Set 'risk accepted' flag, so that the risk dialog doesn't show up
 @pytest.fixture(scope="function")
-def risk_accepted(page_with_trace):
+def risk_accepted(page: Page):
     script = "localStorage.setItem('vega_risk_accepted', 'true'); localStorage.setItem('vega_onboarding_viewed', 'true');"
-
-    page_with_trace.add_init_script(script)
+    page.add_init_script(script)
 
 
 @pytest.fixture(scope="function")

--- a/tests/assets/test_assets.py
+++ b/tests/assets/test_assets.py
@@ -3,90 +3,91 @@ import re
 from playwright.sync_api import expect, Page
 
 label_value_tooltip_pairs = [
-   {
-    'label': 'ID',
-    'value': 'asset-id',
-  },
-  {
-    'label': 'Type',
-    'value': 'Builtin asset',
-    'valueToolTip': 'A Vega builtin asset',
-  },
-  {
-    'label': 'Name',
-    'value': 'tDAI',
-  },
-  {
-    'label': 'Symbol',
-    'value': 'tDAI',
-  },
-  {
-    'label': 'Decimals',
-    'value': '5',
-    'labelTooltip': 'Number of decimal / precision handled by this asset',
-  },
-  {
-    'label': 'Quantum',
-    'value': '0.00001',
-    'labelTooltip': 'The minimum economically meaningful amount of the asset',
-  },
-  {
-    'label': 'Status',
-    'value': 'Enabled',
-    'labelTooltip': 'The status of the asset in the Vega network',
-    'valueToolTip': 'Asset can be used on the Vega network',
-  },
-  {
-    'label': 'Max faucet amount',
-    'value': '10,000,000,000.00',
-    'labelTooltip': 'Maximum amount that can be requested by a party through the built-in asset faucet at a time',
-  },
-  {
-    'label': 'Infrastructure fee account balance',
-    'value': '0.00',
-    'labelTooltip': 'The infrastructure fee account in this asset',
-  },
-  {
-    'label': 'Global reward pool account balance',
-    'value': '0.00',
-    'labelTooltip': 'The global rewards acquired in this asset',
-  },
- 
+    {
+        "label": "ID",
+        "value": "asset-id",
+    },
+    {
+        "label": "Type",
+        "value": "Builtin asset",
+        "valueToolTip": "A Vega builtin asset",
+    },
+    {
+        "label": "Name",
+        "value": "tDAI",
+    },
+    {
+        "label": "Symbol",
+        "value": "tDAI",
+    },
+    {
+        "label": "Decimals",
+        "value": "5",
+        "labelTooltip": "Number of decimal / precision handled by this asset",
+    },
+    {
+        "label": "Quantum",
+        "value": "0.00001",
+        "labelTooltip": "The minimum economically meaningful amount of the asset",
+    },
+    {
+        "label": "Status",
+        "value": "Enabled",
+        "labelTooltip": "The status of the asset in the Vega network",
+        "valueToolTip": "Asset can be used on the Vega network",
+    },
+    {
+        "label": "Max faucet amount",
+        "value": "10,000,000,000.00",
+        "labelTooltip": "Maximum amount that can be requested by a party through the built-in asset faucet at a time",
+    },
+    {
+        "label": "Infrastructure fee account balance",
+        "value": "0.00",
+        "labelTooltip": "The infrastructure fee account in this asset",
+    },
+    {
+        "label": "Global reward pool account balance",
+        "value": "0.00",
+        "labelTooltip": "The global rewards acquired in this asset",
+    },
 ]
+
 
 def tooltip(page: Page, index: int, test_id: str, tooltip: str):
     page.locator(f"data-testid={index}_{test_id}").hover()
-    expect(page.locator('[role="tooltip"]').locator('div')).to_have_text(tooltip)
+    expect(page.locator('[role="tooltip"]').locator("div")).to_have_text(tooltip)
     page.get_by_test_id("dialog-title").click()
 
-@pytest.mark.usefixtures("continuous_market", "auth")
+
+@pytest.mark.usefixtures("page", "continuous_market", "auth")
 def test_asset_details(page: Page):
-    page.goto('/#/portfolio')
+    page.goto("/#/portfolio")
     page.locator('[data-testid="tab-collateral"] >> text=tDAI').click()
 
     for index, pair in enumerate(label_value_tooltip_pairs):
         if index in [7, 8, 9]:  # Skip indices 7, 8, and 9.
             continue
 
-        label = pair.get('label', '')
-        value = pair.get('value', '')
-        label_tooltip = pair.get('labelTooltip', '')
-        value_tooltip = pair.get('valueToolTip', '')
+        label = pair.get("label", "")
+        value = pair.get("value", "")
+        label_tooltip = pair.get("labelTooltip", "")
+        value_tooltip = pair.get("valueToolTip", "")
 
-        if label == 'ID':
+        if label == "ID":
             asset_id_text = page.locator(f"[data-testid='{index}_value']").inner_text()
-            assert re.match(r'^[0-9a-f]{64}$', asset_id_text), f"Expected ID to match pattern but got {asset_id_text}"
+            assert re.match(
+                r"^[0-9a-f]{64}$", asset_id_text
+            ), f"Expected ID to match pattern but got {asset_id_text}"
         else:
             expect(page.locator(f"[data-testid='{index}_label']")).to_have_text(label)
             expect(page.locator(f"[data-testid='{index}_value']")).to_have_text(value)
 
         if label_tooltip:
-            tooltip(page, index, 'label', label_tooltip)
+            tooltip(page, index, "label", label_tooltip)
 
         if value_tooltip:
-            tooltip(page, index, 'value', value_tooltip)
+            tooltip(page, index, "value", value_tooltip)
 
     page.get_by_test_id("dialog-close").click()
     assert not page.query_selector("dialog-content")
-
-

--- a/tests/chart_depth/test_chart_depth.py
+++ b/tests/chart_depth/test_chart_depth.py
@@ -2,7 +2,7 @@ import pytest
 from playwright.sync_api import expect, Page
 
 
-@pytest.mark.usefixtures("continuous_market", "risk_accepted")
+@pytest.mark.usefixtures("page", "continuous_market", "risk_accepted")
 def test_see_market_depth_chart(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     # Click on the 'Depth' tab
@@ -11,4 +11,3 @@ def test_see_market_depth_chart(continuous_market, page: Page):
     # 6006-DEPC-001
     expect(page.get_by_test_id("tab-depth")).to_be_visible()
     expect(page.locator('[class^="depth-chart-module_canvas__"]').first).to_be_visible()
-

--- a/tests/deal_ticket/test_fees_margin_estimations.py
+++ b/tests/deal_ticket/test_fees_margin_estimations.py
@@ -17,7 +17,7 @@ item_value = "item-value"
 market_trading_mode = "market-trading-mode"
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
+@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth")
 def test_margin_and_fees_estimations(continuous_market, vega: VegaService, page: Page):
     # setup continuous trading market with one user buy trade
     market_id = continuous_market

--- a/tests/deal_ticket/test_stop_order.py
+++ b/tests/deal_ticket/test_stop_order.py
@@ -5,7 +5,6 @@ from vega_sim.service import VegaService
 from actions.vega import submit_order
 from datetime import datetime, timedelta
 
-
 # Defined namedtuples
 WalletConfig = namedtuple("WalletConfig", ["name", "passphrase"])
 
@@ -16,7 +15,7 @@ TERMINATE_WALLET = WalletConfig("FJMKnwfZdd48C8NqvYrG", "bY3DxwtsCstMIIZdNpKs")
 
 stop_order_btn = "order-type-Stop"
 stop_limit_order_btn = "order-type-StopLimit"
-stop_market_order_btn =  "order-type-StopMarket"
+stop_market_order_btn = "order-type-StopMarket"
 order_side_sell = "order-side-SIDE_SELL"
 trigger_above = "triggerDirection-risesAbove"
 trigger_below = "triggerDirection-fallsBelow"
@@ -35,7 +34,7 @@ submit_stop_order = "place-order"
 stop_orders_tab = "Stop orders"
 row_table = "row"
 cancel = "cancel"
-market_name_col =  '[col-id="market.tradableInstrument.instrument.code"]'
+market_name_col = '[col-id="market.tradableInstrument.instrument.code"]'
 trigger_col = '[col-id="trigger"]'
 expiresAt_col = '[col-id="expiresAt"]'
 size_col = '[col-id="submission.size"]'
@@ -44,7 +43,8 @@ status_col = '[col-id="status"]'
 price_col = '[col-id="submission.price"]'
 timeInForce_col = '[col-id="submission.timeInForce"]'
 updatedAt_col = '[col-id="updatedAt"]'
-close_toast= "toast-close"
+close_toast = "toast-close"
+
 
 def create_position(vega: VegaService, market_id):
     submit_order(vega, "Key 1", market_id, "SIDE_SELL", 100, 110)
@@ -52,10 +52,10 @@ def create_position(vega: VegaService, market_id):
     vega.forward("10s")
     vega.wait_for_total_catchup
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_stop_order_form_error_validation(continuous_market, page: Page):
 
-    # 7002-SORD-032 
+@pytest.mark.usefixtures("page", "continuous_market", "auth")
+def test_stop_order_form_error_validation(continuous_market, page: Page):
+    # 7002-SORD-032
 
     market_id = continuous_market
     page.goto(f"/#/markets/{market_id}")
@@ -64,16 +64,22 @@ def test_stop_order_form_error_validation(continuous_market, page: Page):
     page.get_by_test_id(stop_limit_order_btn).click()
     page.get_by_test_id(order_side_sell).click()
     page.get_by_test_id(submit_stop_order).click()
-    expect(page.get_by_test_id("stop-order-error-message-trigger-price")).to_have_text("You need provide a price")
-    expect(page.get_by_test_id("stop-order-error-message-size")).to_have_text("Size cannot be lower than 1")
-    
+    expect(page.get_by_test_id("stop-order-error-message-trigger-price")).to_have_text(
+        "You need provide a price"
+    )
+    expect(page.get_by_test_id("stop-order-error-message-size")).to_have_text(
+        "Size cannot be lower than 1"
+    )
+
     page.get_by_test_id(order_size).fill("1")
     page.get_by_test_id(order_price).fill("0.0000001")
-    expect(page.get_by_test_id("stop-order-error-message-price")).to_have_text("Price cannot be lower than 0.00001")
+    expect(page.get_by_test_id("stop-order-error-message-price")).to_have_text(
+        "Price cannot be lower than 0.00001"
+    )
 
-@pytest.mark.usefixtures("continuous_market", "auth")
+
+@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth")
 def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: Page):
-
     market_id = continuous_market
     page.goto(f"/#/markets/{market_id}")
 
@@ -91,29 +97,42 @@ def test_submit_stop_order_rejected(continuous_market, vega: VegaService, page: 
     page.get_by_test_id(close_toast).click()
 
     page.get_by_role(row_table).locator(market_name_col).nth(1).is_visible()
-    expect((page.get_by_role(row_table).locator(market_name_col)).nth(1)).to_have_text("BTC:DAI_2023Futr")
-    expect((page.get_by_role(row_table).locator(trigger_col)).nth(1)).to_have_text("Mark > 103.00")
+    expect((page.get_by_role(row_table).locator(market_name_col)).nth(1)).to_have_text(
+        "BTC:DAI_2023Futr"
+    )
+    expect((page.get_by_role(row_table).locator(trigger_col)).nth(1)).to_have_text(
+        "Mark > 103.00"
+    )
     expect((page.get_by_role(row_table).locator(expiresAt_col)).nth(1)).to_have_text("")
     expect((page.get_by_role(row_table).locator(size_col)).nth(1)).to_have_text("+3")
-    expect((page.get_by_role(row_table).locator(submission_type)).nth(1)).to_have_text("Market")
-    expect((page.get_by_role(row_table).locator(status_col)).nth(1)).to_have_text("Rejected")
+    expect((page.get_by_role(row_table).locator(submission_type)).nth(1)).to_have_text(
+        "Market"
+    )
+    expect((page.get_by_role(row_table).locator(status_col)).nth(1)).to_have_text(
+        "Rejected"
+    )
     expect((page.get_by_role(row_table).locator(price_col)).nth(1)).to_have_text("-")
-    expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("FOK")
-    expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
+    expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text(
+        "FOK"
+    )
+    expect(
+        (page.get_by_role(row_table).locator(updatedAt_col)).nth(1)
+    ).not_to_be_empty()
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_submit_stop_market_order_triggered(continuous_market, vega: VegaService, page: Page):
+@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth")
+def test_submit_stop_market_order_triggered(
+    continuous_market, vega: VegaService, page: Page
+):
     # 7002-SORD-071
     # 7002-SORD-074
     # 7002-SORD-075
     # 7002-SORD-067
     # 7002-SORD-068
-  
 
     market_id = continuous_market
     page.goto(f"/#/markets/{market_id}")
-    
+
     # create a position because stop order is reduce only type
     create_position(vega, market_id)
 
@@ -122,12 +141,14 @@ def test_submit_stop_market_order_triggered(continuous_market, vega: VegaService
     page.get_by_test_id(stop_market_order_btn).click()
     page.get_by_test_id(order_side_sell).click()
     page.get_by_test_id(trigger_price).fill("103")
-    expect(page.get_by_test_id("sidebar-content").get_by_test_id("price")).to_have_text("~103.00 BTC")
+    expect(page.get_by_test_id("sidebar-content").get_by_test_id("price")).to_have_text(
+        "~103.00 BTC"
+    )
     page.get_by_test_id(order_size).fill("1")
     page.get_by_test_id(expire).click()
     expires_at = datetime.now() + timedelta(days=1)
-    expires_at_input_value = expires_at.strftime('%Y-%m-%dT%H:%M:%S')
-    page.get_by_test_id('date-picker-field').fill(expires_at_input_value)
+    expires_at_input_value = expires_at.strftime("%Y-%m-%dT%H:%M:%S")
+    page.get_by_test_id("date-picker-field").fill(expires_at_input_value)
     page.get_by_test_id(expiry_strategy_cancel).click()
 
     page.get_by_test_id(submit_stop_order).click()
@@ -136,22 +157,39 @@ def test_submit_stop_market_order_triggered(continuous_market, vega: VegaService
     vega.wait_fn(1)
     vega.forward("10s")
     vega.wait_for_total_catchup()
-    page.wait_for_selector('[data-testid="toast-close"]', state='visible')
+    page.wait_for_selector('[data-testid="toast-close"]', state="visible")
     page.get_by_test_id(close_toast).click()
 
     page.get_by_role(row_table).locator(market_name_col).nth(1).is_visible()
-    expect((page.get_by_role(row_table).locator(market_name_col)).nth(1)).to_have_text("BTC:DAI_2023Futr")
-    expect((page.get_by_role(row_table).locator(trigger_col)).nth(1)).to_have_text("Mark > 103.00")
-    expect((page.get_by_role(row_table).locator(expiresAt_col)).nth(1)).to_contain_text("Cancels")
+    expect((page.get_by_role(row_table).locator(market_name_col)).nth(1)).to_have_text(
+        "BTC:DAI_2023Futr"
+    )
+    expect((page.get_by_role(row_table).locator(trigger_col)).nth(1)).to_have_text(
+        "Mark > 103.00"
+    )
+    expect((page.get_by_role(row_table).locator(expiresAt_col)).nth(1)).to_contain_text(
+        "Cancels"
+    )
     expect((page.get_by_role(row_table).locator(size_col)).nth(1)).to_have_text("-1")
-    expect((page.get_by_role(row_table).locator(submission_type)).nth(1)).to_have_text("Market")
-    expect((page.get_by_role(row_table).locator(status_col)).nth(1)).to_have_text("Triggered")
+    expect((page.get_by_role(row_table).locator(submission_type)).nth(1)).to_have_text(
+        "Market"
+    )
+    expect((page.get_by_role(row_table).locator(status_col)).nth(1)).to_have_text(
+        "Triggered"
+    )
     expect((page.get_by_role(row_table).locator(price_col)).nth(1)).to_have_text("-")
-    expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("FOK")
-    expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
+    expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text(
+        "FOK"
+    )
+    expect(
+        (page.get_by_role(row_table).locator(updatedAt_col)).nth(1)
+    ).not_to_be_empty()
+
 
 @pytest.mark.usefixtures("continuous_market", "auth")
-def test_submit_stop_limit_order_pending(continuous_market, vega: VegaService, page: Page):
+def test_submit_stop_limit_order_pending(
+    continuous_market, vega: VegaService, page: Page
+):
     # 7002-SORD-071
     # 7002-SORD-074
     # 7002-SORD-075
@@ -174,31 +212,49 @@ def test_submit_stop_limit_order_pending(continuous_market, vega: VegaService, p
     page.get_by_test_id("order-tif").select_option("TIME_IN_FORCE_IOC")
     page.get_by_test_id(expire).click()
     expires_at = datetime.now() + timedelta(days=1)
-    expires_at_input_value = expires_at.strftime('%Y-%m-%dT%H:%M:%S')
-    page.get_by_test_id('date-picker-field').fill(expires_at_input_value)
+    expires_at_input_value = expires_at.strftime("%Y-%m-%dT%H:%M:%S")
+    page.get_by_test_id("date-picker-field").fill(expires_at_input_value)
     page.get_by_test_id(submit_stop_order).click()
     page.get_by_test_id(stop_orders_tab).click()
 
     vega.wait_fn(1)
     vega.forward("10s")
     vega.wait_for_total_catchup()
-    page.wait_for_selector('[data-testid="toast-close"]', state='visible')
+    page.wait_for_selector('[data-testid="toast-close"]', state="visible")
     page.get_by_test_id(close_toast).click()
 
     page.get_by_role(row_table).locator(market_name_col).nth(1).is_visible()
-    expect((page.get_by_role(row_table).locator(market_name_col)).nth(1)).to_have_text("BTC:DAI_2023Futr")
-    expect((page.get_by_role(row_table).locator(trigger_col)).nth(1)).to_have_text("Mark < 102.00")
-    expect((page.get_by_role(row_table).locator(expiresAt_col)).nth(1)).to_contain_text("Submit")
+    expect((page.get_by_role(row_table).locator(market_name_col)).nth(1)).to_have_text(
+        "BTC:DAI_2023Futr"
+    )
+    expect((page.get_by_role(row_table).locator(trigger_col)).nth(1)).to_have_text(
+        "Mark < 102.00"
+    )
+    expect((page.get_by_role(row_table).locator(expiresAt_col)).nth(1)).to_contain_text(
+        "Submit"
+    )
     expect((page.get_by_role(row_table).locator(size_col)).nth(1)).to_have_text("-1")
-    expect((page.get_by_role(row_table).locator(submission_type)).nth(1)).to_have_text("Limit")
-    expect((page.get_by_role(row_table).locator(status_col)).nth(1)).to_have_text("Pending")
-    expect((page.get_by_role(row_table).locator(price_col)).nth(1)).to_have_text("99.00")
-    expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text("IOC")
-    expect((page.get_by_role(row_table).locator(updatedAt_col)).nth(1)).not_to_be_empty()
+    expect((page.get_by_role(row_table).locator(submission_type)).nth(1)).to_have_text(
+        "Limit"
+    )
+    expect((page.get_by_role(row_table).locator(status_col)).nth(1)).to_have_text(
+        "Pending"
+    )
+    expect((page.get_by_role(row_table).locator(price_col)).nth(1)).to_have_text(
+        "99.00"
+    )
+    expect((page.get_by_role(row_table).locator(timeInForce_col)).nth(1)).to_have_text(
+        "IOC"
+    )
+    expect(
+        (page.get_by_role(row_table).locator(updatedAt_col)).nth(1)
+    ).not_to_be_empty()
+
 
 @pytest.mark.usefixtures("continuous_market", "auth")
-def test_submit_stop_limit_order_cancel(continuous_market, vega: VegaService, page: Page):
-
+def test_submit_stop_limit_order_cancel(
+    continuous_market, vega: VegaService, page: Page
+):
     market_id = continuous_market
     page.goto(f"/#/markets/{market_id}")
 
@@ -213,7 +269,7 @@ def test_submit_stop_limit_order_cancel(continuous_market, vega: VegaService, pa
     page.get_by_test_id(trigger_price).fill("102")
     page.get_by_test_id(order_price).fill("99")
     page.get_by_test_id(order_size).fill("1")
-    
+
     page.get_by_test_id(submit_stop_order).click()
     page.get_by_test_id(stop_orders_tab).click()
 
@@ -228,11 +284,13 @@ def test_submit_stop_limit_order_cancel(continuous_market, vega: VegaService, pa
     vega.wait_for_total_catchup()
     page.get_by_test_id(close_toast).click()
 
-    expect((page.get_by_role(row_table).locator('[col-id="status"]')).nth(1)).to_have_text("Cancelled")
-    
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_stop_market_order_form_validation(continuous_market, vega: VegaService, page: Page):
+    expect(
+        (page.get_by_role(row_table).locator('[col-id="status"]')).nth(1)
+    ).to_have_text("Cancelled")
 
+
+@pytest.mark.usefixtures("continuous_market", "auth")
+def test_stop_market_order_form_validation(continuous_market, page: Page):
     # 7002-SORD-052
     # 7002-SORD-055
     # 7002-SORD-056
@@ -243,25 +301,33 @@ def test_stop_market_order_form_validation(continuous_market, vega: VegaService,
 
     market_id = continuous_market
     page.goto(f"/#/markets/{market_id}")
-    
+
     page.get_by_test_id(stop_order_btn).click()
     page.get_by_test_id(stop_market_order_btn).is_visible()
     page.get_by_test_id(stop_market_order_btn).click()
-    expect(page.get_by_test_id("sidebar-content").get_by_text("Trigger")).to_be_visible()
-    expect(page.locator('[for="triggerDirection-risesAbove"]')).to_have_text("Rises above")
-    expect(page.locator('[for="triggerDirection-fallsBelow"]')).to_have_text("Falls below")
+    expect(
+        page.get_by_test_id("sidebar-content").get_by_text("Trigger")
+    ).to_be_visible()
+    expect(page.locator('[for="triggerDirection-risesAbove"]')).to_have_text(
+        "Rises above"
+    )
+    expect(page.locator('[for="triggerDirection-fallsBelow"]')).to_have_text(
+        "Falls below"
+    )
     page.get_by_test_id(trigger_price).click()
     expect(page.get_by_test_id(trigger_price)).to_be_empty
     expect(page.locator('[for="triggerType-price"]')).to_have_text("Price")
-    expect(page.locator('[for="triggerType-trailingPercentOffset"]')).to_have_text("Trailing Percent Offset")    
+    expect(page.locator('[for="triggerType-trailingPercentOffset"]')).to_have_text(
+        "Trailing Percent Offset"
+    )
     expect(page.locator('[for="input-price-quote"]')).to_have_text("Size")
     page.get_by_test_id(order_size).click()
     expect(page.get_by_test_id(order_size)).to_be_empty
     expect(page.get_by_test_id(order_price)).not_to_be_visible()
-  
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_stop_limit_order_form_validation(continuous_market, vega: VegaService, page: Page):
 
+
+@pytest.mark.usefixtures("continuous_market", "auth")
+def test_stop_limit_order_form_validation(continuous_market, page: Page):
     # 7002-SORD-020
     # 7002-SORD-021
     # 7002-SORD-022
@@ -280,15 +346,23 @@ def test_stop_limit_order_form_validation(continuous_market, vega: VegaService, 
     page.get_by_test_id(stop_order_btn).click()
     page.get_by_test_id(stop_limit_order_btn).is_visible()
     page.get_by_test_id(stop_limit_order_btn).click()
-    expect(page.get_by_test_id("sidebar-content").get_by_text("Trigger")).to_be_visible()
-    expect(page.locator('[for="triggerDirection-risesAbove"]')).to_have_text("Rises above")
+    expect(
+        page.get_by_test_id("sidebar-content").get_by_text("Trigger")
+    ).to_be_visible()
+    expect(page.locator('[for="triggerDirection-risesAbove"]')).to_have_text(
+        "Rises above"
+    )
     expect(page.locator('[for="triggerDirection-risesAbove"]')).to_be_checked
-    expect(page.locator('[for="triggerDirection-fallsBelow"]')).to_have_text("Falls below")
+    expect(page.locator('[for="triggerDirection-fallsBelow"]')).to_have_text(
+        "Falls below"
+    )
     page.get_by_test_id(trigger_price).click()
     expect(page.get_by_test_id(trigger_price)).to_be_empty
     expect(page.locator('[for="triggerType-price"]')).to_have_text("Price")
     expect(page.locator('[for="triggerType-price"]')).to_be_checked
-    expect(page.locator('[for="triggerType-trailingPercentOffset"]')).to_have_text("Trailing Percent Offset")    
+    expect(page.locator('[for="triggerType-trailingPercentOffset"]')).to_have_text(
+        "Trailing Percent Offset"
+    )
     expect(page.locator('[for="input-price-quote"]').first).to_have_text("Size")
     expect(page.locator('[for="input-price-quote"]').last).to_have_text("Price (BTC)")
     page.get_by_test_id(order_size).click()

--- a/tests/get_started/test_get_started.py
+++ b/tests/get_started/test_get_started.py
@@ -1,60 +1,81 @@
 import pytest
 from playwright.sync_api import expect, Page
-from playwright.sync_api import expect
 from vega_sim.service import VegaService
+from fixtures.market import setup_simple_market
+from conftest import init_vega
 
-@pytest.mark.usefixtures("simple_market")
+
+@pytest.fixture(scope="module")
+def vega():
+    with init_vega() as vega:
+        yield vega
+
+
+# we can reuse vega market-sim service and market in almost all tests
+@pytest.fixture(scope="module")
+def simple_market(vega: VegaService):
+    return setup_simple_market(vega)
+
+
+@pytest.mark.usefixtures("page")
 def test_get_started_dialog(page: Page):
     page.goto(f"/#/disclaimer")
-    expect(page.get_by_test_id('welcome-dialog')).to_be_visible()
-    expect(page.get_by_test_id('get-started-button')).to_be_visible()
-    page.get_by_test_id('get-started-button').click()
-    expect(page.get_by_test_id('connector-jsonRpc')).to_be_visible()
-    
-@pytest.mark.usefixtures("simple_market","risk_accepted")
+    expect(page.get_by_test_id("welcome-dialog")).to_be_visible()
+    expect(page.get_by_test_id("get-started-button")).to_be_visible()
+    page.get_by_test_id("get-started-button").click()
+    expect(page.get_by_test_id("connector-jsonRpc")).to_be_visible()
+
+
+@pytest.mark.usefixtures("page", "risk_accepted")
 def test_get_started_seen_already(simple_market, page: Page):
     page.goto(f"/#/markets/{simple_market}")
-    locator = page.get_by_test_id('connect-vega-wallet')
-    page.wait_for_selector('[data-testid="connect-vega-wallet"]', state='attached')
+    locator = page.get_by_test_id("connect-vega-wallet")
+    page.wait_for_selector('[data-testid="connect-vega-wallet"]', state="attached")
     expect(locator).to_be_enabled
     expect(locator).to_be_visible
-    expect(locator).to_have_text('Get started')
+    expect(locator).to_have_text("Get started")
 
-@pytest.mark.usefixtures("simple_market")
+
+@pytest.mark.usefixtures("page")
 def test_browser_wallet_installed(simple_market, page: Page):
     page.add_init_script("window.vega = {}")
     page.goto(f"/#/markets/{simple_market}")
-    locator = page.get_by_test_id('connect-vega-wallet')
-    page.wait_for_selector('[data-testid="connect-vega-wallet"]', state='attached')
+    locator = page.get_by_test_id("connect-vega-wallet")
+    page.wait_for_selector('[data-testid="connect-vega-wallet"]', state="attached")
     expect(locator).to_be_enabled
     expect(locator).to_be_visible
-    expect(locator).to_have_text('Connect')
+    expect(locator).to_have_text("Connect")
 
-@pytest.mark.usefixtures("simple_market","risk_accepted")
+
+@pytest.mark.usefixtures("page", "risk_accepted")
 def test_get_started_deal_ticket(simple_market, page: Page):
     page.goto(f"/#/markets/{simple_market}")
-    locator = page.get_by_test_id('get-started-button')
-    page.wait_for_selector('[data-testid="get-started-banner"]', state='attached')
-    expect(page.get_by_test_id('get-started-banner')).to_be_visible
+    locator = page.get_by_test_id("get-started-button")
+    page.wait_for_selector('[data-testid="get-started-banner"]', state="attached")
+    expect(page.get_by_test_id("get-started-banner")).to_be_visible
     expect(locator).to_be_enabled
-    expect(locator).to_have_text('Get started')
+    expect(locator).to_have_text("Get started")
 
-@pytest.mark.usefixtures("simple_market","risk_accepted")
+
+@pytest.mark.usefixtures("page", "risk_accepted")
 def test_browser_wallet_installed_deal_ticket(simple_market, page: Page):
     page.add_init_script("window.vega = {}")
     page.goto(f"/#/markets/{simple_market}")
-    page.wait_for_selector('[data-testid="sidebar-content"]', state='visible')
-    expect(page.get_by_test_id('get-started-banner')).not_to_be_visible()
+    page.wait_for_selector('[data-testid="sidebar-content"]', state="visible")
+    expect(page.get_by_test_id("get-started-banner")).not_to_be_visible()
 
-@pytest.mark.usefixtures("simple_market")
+
+@pytest.mark.usefixtures("page")
 def test_get_started_browse_all(vega: VegaService, page: Page):
     page.goto("/")
     page.get_by_test_id("browse-markets-button").click()
     expect(page).to_have_url(f"http://localhost:{vega.console_port}/#/markets/all")
-    assert page.evaluate("localStorage.getItem('vega_onboarding_viewed')") == 'true'
+    assert page.evaluate("localStorage.getItem('vega_onboarding_viewed')") == "true"
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_redirect_default_market(continuous_market, vega:VegaService, page: Page):
+@pytest.mark.usefixtures("page", "auth")
+def test_redirect_default_market(continuous_market, vega: VegaService, page: Page):
     page.goto("/")
-    expect(page).to_have_url(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
+    expect(page).to_have_url(
+        f"http://localhost:{vega.console_port}/#/markets/{continuous_market}"
+    )

--- a/tests/iceberg_orders/test_iceberg_orders.py
+++ b/tests/iceberg_orders/test_iceberg_orders.py
@@ -15,94 +15,151 @@ TERMINATE_WALLET = WalletConfig("FJMKnwfZdd48C8NqvYrG", "bY3DxwtsCstMIIZdNpKs")
 
 wallets = [MM_WALLET, MM_WALLET2, TERMINATE_WALLET]
 
+
 def hover_and_assert_tooltip(page, element_text):
     element = page.get_by_text(element_text)
     element.hover()
     expect(page.get_by_role("tooltip")).to_be_visible()
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_iceberg_submit(continuous_market,vega: VegaService,   page: Page):
-    page.goto(f"/#/markets/{continuous_market}")
-    page.get_by_test_id('iceberg').click()
-    page.get_by_test_id('order-peak-size').fill("2")
-    page.get_by_test_id('order-minimum-size').fill("1")
-    page.get_by_test_id('order-size').fill("3")
-    page.get_by_test_id('order-price').fill("107")
-    page.get_by_test_id('place-order').click()
 
-    expect(page.get_by_test_id('toast-content')).to_have_text('Awaiting confirmationPlease wait for your transaction to be confirmedView in block explorer')
-    
+@pytest.mark.usefixtures("page", "vega", "continuous_market", "auth")
+def test_iceberg_submit(continuous_market, vega: VegaService, page: Page):
+    page.goto(f"/#/markets/{continuous_market}")
+    page.get_by_test_id("iceberg").click()
+    page.get_by_test_id("order-peak-size").fill("2")
+    page.get_by_test_id("order-minimum-size").fill("1")
+    page.get_by_test_id("order-size").fill("3")
+    page.get_by_test_id("order-price").fill("107")
+    page.get_by_test_id("place-order").click()
+
+    expect(page.get_by_test_id("toast-content")).to_have_text(
+        "Awaiting confirmationPlease wait for your transaction to be confirmedView in block explorer"
+    )
+
     vega.wait_fn(10)
     vega.forward("10s")
     vega.wait_for_total_catchup()
-    expect(page.get_by_test_id('toast-content')).to_have_text ('Order filledYour transaction has been confirmed View in block explorerSubmit order - filledBTC:DAI_2023+3 @ 107.00 tDAI')
-    
-    
-@pytest.mark.usefixtures("continuous_market", "auth")
+    expect(page.get_by_test_id("toast-content")).to_have_text(
+        "Order filledYour transaction has been confirmed View in block explorerSubmit order - filledBTC:DAI_2023+3 @ 107.00 tDAI"
+    )
+
+
+@pytest.mark.usefixtures("page", "continuous_market", "auth")
 def test_iceberg_tooltips(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     hover_and_assert_tooltip(page, "Iceberg")
-    page.get_by_test_id('iceberg').click()
-    hover_and_assert_tooltip(page, 'Peak size')
-    hover_and_assert_tooltip(page, 'Minimum size')
+    page.get_by_test_id("iceberg").click()
+    hover_and_assert_tooltip(page, "Peak size")
+    hover_and_assert_tooltip(page, "Minimum size")
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_iceberg_validations(continuous_market,  page: Page):
+
+@pytest.mark.usefixtures("page", "continuous_market", "auth")
+def test_iceberg_validations(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
-    page.get_by_test_id('iceberg').click()
-    page.get_by_test_id('place-order').click()
-    expect(page.get_by_test_id('deal-ticket-peak-error-message-size-limit')).to_be_visible()
-    expect(page.get_by_test_id('deal-ticket-peak-error-message-size-limit')).to_have_text('You need to provide a peak size')
-    expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_be_visible()
-    expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_have_text('You need to provide a minimum visible size')
-    page.get_by_test_id('order-peak-size').fill('1')
-    page.get_by_test_id('order-minimum-size').fill('2')
-    expect(page.get_by_test_id('deal-ticket-peak-error-message-size-limit')).to_be_visible()
-    expect(page.get_by_test_id('deal-ticket-peak-error-message-size-limit')).to_have_text('Peak size cannot be greater than the size (0)')
-    expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_be_visible()
-    expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_have_text('Minimum visible size cannot be greater than the peak size (1)')
-    page.get_by_test_id('order-minimum-size').fill('0.1')
-    expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_be_visible()
-    expect(page.get_by_test_id('deal-ticket-minimum-error-message-size-limit')).to_have_text('Minimum visible size cannot be lower than 1')
+    page.get_by_test_id("iceberg").click()
+    page.get_by_test_id("place-order").click()
+    expect(
+        page.get_by_test_id("deal-ticket-peak-error-message-size-limit")
+    ).to_be_visible()
+    expect(
+        page.get_by_test_id("deal-ticket-peak-error-message-size-limit")
+    ).to_have_text("You need to provide a peak size")
+    expect(
+        page.get_by_test_id("deal-ticket-minimum-error-message-size-limit")
+    ).to_be_visible()
+    expect(
+        page.get_by_test_id("deal-ticket-minimum-error-message-size-limit")
+    ).to_have_text("You need to provide a minimum visible size")
+    page.get_by_test_id("order-peak-size").fill("1")
+    page.get_by_test_id("order-minimum-size").fill("2")
+    expect(
+        page.get_by_test_id("deal-ticket-peak-error-message-size-limit")
+    ).to_be_visible()
+    expect(
+        page.get_by_test_id("deal-ticket-peak-error-message-size-limit")
+    ).to_have_text("Peak size cannot be greater than the size (0)")
+    expect(
+        page.get_by_test_id("deal-ticket-minimum-error-message-size-limit")
+    ).to_be_visible()
+    expect(
+        page.get_by_test_id("deal-ticket-minimum-error-message-size-limit")
+    ).to_have_text("Minimum visible size cannot be greater than the peak size (1)")
+    page.get_by_test_id("order-minimum-size").fill("0.1")
+    expect(
+        page.get_by_test_id("deal-ticket-minimum-error-message-size-limit")
+    ).to_be_visible()
+    expect(
+        page.get_by_test_id("deal-ticket-minimum-error-message-size-limit")
+    ).to_have_text("Minimum visible size cannot be lower than 1")
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_iceberg_open_order(continuous_market,vega: VegaService, page: Page):
-     page.goto(f"/#/markets/{continuous_market}")
-     
-     submit_order(vega, "Key 1", vega.all_markets()[0].id, "SIDE_SELL", 102, 101,2, 1)
-     vega.forward("10s")
-     vega.wait_for_total_catchup()
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_iceberg_open_order(continuous_market, vega: VegaService, page: Page):
+    page.goto(f"/#/markets/{continuous_market}")
 
-     page.wait_for_selector(".ag-center-cols-container .ag-row")   
-     expect(page.locator(".ag-center-cols-container .ag-row [col-id='openVolume'] [data-testid='stack-cell-primary']")).to_have_text("-98")
-     page.get_by_test_id("Open").click()
-     page.wait_for_selector(".ag-center-cols-container .ag-row")   
-     
-     
-     expect(page.locator(".ag-center-cols-container .ag-row [col-id='remaining']")).to_have_text("99")
-     expect(page.locator(".ag-center-cols-container .ag-row [col-id='size']")).to_have_text("-102")
-     expect(page.locator(".ag-center-cols-container .ag-row [col-id='type'] ")).to_have_text("Limit (Iceberg)")
-     expect(page.locator(".ag-center-cols-container .ag-row [col-id='status']")).to_have_text("Active")
-     expect(page.get_by_test_id("price-10100000")).to_be_visible
-     expect(page.get_by_test_id("ask-vol-10100000")).to_have_text("3")
-     page.get_by_test_id("Trades").click()
-     expect(page.locator('[id^="cell-price-"]').first).to_have_text("101.50")
-     expect(page.locator('[id^="cell-size-"]').first).to_have_text("99")
+    submit_order(vega, "Key 1", vega.all_markets()[0].id, "SIDE_SELL", 102, 101, 2, 1)
+    vega.forward("10s")
+    vega.wait_for_total_catchup()
 
-     submit_order(vega, MM_WALLET2.name, vega.all_markets()[0].id, "SIDE_BUY", 103, 101)
-     
-     vega.forward("10s")
-     vega.wait_for_total_catchup()
-     expect(page.locator('[data-testid="tab-open-orders"] .ag-center-cols-container .ag-row')).not_to_be_visible
-     page.get_by_test_id("Closed").click()
-     expect(page.locator(".ag-center-cols-container .ag-row [col-id='remaining']").first).to_have_text("102")
-     expect(page.locator('[data-testid="tab-closed-orders"] .ag-center-cols-container .ag-row [col-id=\'size\']').first).to_have_text("-102")
-     expect(page.locator('[data-testid="tab-closed-orders"] .ag-center-cols-container .ag-row [col-id=\'type\']').first).to_have_text("Limit (Iceberg)")
-     expect(page.locator('[data-testid="tab-closed-orders"] .ag-center-cols-container .ag-row [col-id=\'status\']').first).to_have_text("Filled")
-     expect(page.locator('[id^="cell-price-"]').nth(2)).to_have_text("101.00")
-     expect(page.locator('[id^="cell-size-"]').nth(2)).to_have_text("3")
-    
+    page.wait_for_selector(".ag-center-cols-container .ag-row")
+    expect(
+        page.locator(
+            ".ag-center-cols-container .ag-row [col-id='openVolume'] [data-testid='stack-cell-primary']"
+        )
+    ).to_have_text("-98")
+    page.get_by_test_id("Open").click()
+    page.wait_for_selector(".ag-center-cols-container .ag-row")
+
+    expect(
+        page.locator(".ag-center-cols-container .ag-row [col-id='remaining']")
+    ).to_have_text("99")
+    expect(
+        page.locator(".ag-center-cols-container .ag-row [col-id='size']")
+    ).to_have_text("-102")
+    expect(
+        page.locator(".ag-center-cols-container .ag-row [col-id='type'] ")
+    ).to_have_text("Limit (Iceberg)")
+    expect(
+        page.locator(".ag-center-cols-container .ag-row [col-id='status']")
+    ).to_have_text("Active")
+    expect(page.get_by_test_id("price-10100000")).to_be_visible
+    expect(page.get_by_test_id("ask-vol-10100000")).to_have_text("3")
+    page.get_by_test_id("Trades").click()
+    expect(page.locator('[id^="cell-price-"]').first).to_have_text("101.50")
+    expect(page.locator('[id^="cell-size-"]').first).to_have_text("99")
+
+    submit_order(vega, MM_WALLET2.name, vega.all_markets()[0].id, "SIDE_BUY", 103, 101)
+
+    vega.forward("10s")
+    vega.wait_for_total_catchup()
+    expect(
+        page.locator(
+            '[data-testid="tab-open-orders"] .ag-center-cols-container .ag-row'
+        )
+    ).not_to_be_visible
+    page.get_by_test_id("Closed").click()
+    expect(
+        page.locator(".ag-center-cols-container .ag-row [col-id='remaining']").first
+    ).to_have_text("102")
+    expect(
+        page.locator(
+            "[data-testid=\"tab-closed-orders\"] .ag-center-cols-container .ag-row [col-id='size']"
+        ).first
+    ).to_have_text("-102")
+    expect(
+        page.locator(
+            "[data-testid=\"tab-closed-orders\"] .ag-center-cols-container .ag-row [col-id='type']"
+        ).first
+    ).to_have_text("Limit (Iceberg)")
+    expect(
+        page.locator(
+            "[data-testid=\"tab-closed-orders\"] .ag-center-cols-container .ag-row [col-id='status']"
+        ).first
+    ).to_have_text("Filled")
+    expect(page.locator('[id^="cell-price-"]').nth(2)).to_have_text("101.00")
+    expect(page.locator('[id^="cell-size-"]').nth(2)).to_have_text("3")
+
+
 def verify_order_label(page: Page, test_id: str, expected_text: str):
     element = page.get_by_test_id(test_id)
     expect(element).to_be_visible()
@@ -113,5 +170,3 @@ def verify_order_value(page: Page, test_id: str, expected_text: str):
     element = page.get_by_test_id(test_id)
     expect(element).to_be_visible()
     expect(element).to_have_text(expected_text)
-
-    

--- a/tests/market/test_market.py
+++ b/tests/market/test_market.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from playwright.sync_api import Page, expect
 from vega_sim.service import VegaService
 from actions.vega import submit_order
+from conftest import init_page, init_vega
 
 
 # Wallet Configurations
@@ -14,7 +15,9 @@ TERMINATE_WALLET = WalletConfig("FJMKnwfZdd48C8NqvYrG", "bY3DxwtsCstMIIZdNpKs")
 
 wallets = [MM_WALLET, MM_WALLET2, TERMINATE_WALLET]
 
-table_row_selector = '[data-testid="tab-open-markets"] .ag-center-cols-container .ag-row'
+table_row_selector = (
+    '[data-testid="tab-open-markets"] .ag-center-cols-container .ag-row'
+)
 trading_mode_col = '[col-id="tradingMode"]'
 state_col = '[col-id="state"]'
 item_value = "item-value"
@@ -35,8 +38,8 @@ initial_spread: float = 0.1
 market_name = "BTC:DAI_2023"
 
 
-@pytest.mark.usefixtures("simple_market", "risk_accepted")
-def test_price_monitoring(simple_market, vega: VegaService, page: Page):    
+@pytest.mark.usefixtures("vega", "page", "simple_market", "risk_accepted")
+def test_price_monitoring(simple_market, vega: VegaService, page: Page):
     page.goto(f"/#/markets/all")
     expect(page.locator(table_row_selector).locator(trading_mode_col)).to_have_text(
         "Opening auction"
@@ -47,7 +50,9 @@ def test_price_monitoring(simple_market, vega: VegaService, page: Page):
     result = page.get_by_text(market_name)
     result.first.click()
     page.get_by_test_id(market_trading_mode).get_by_text("Opening auction").hover()
-    expect(page.get_by_test_id("opening-auction-sub-status").first).to_have_text("Opening auction: Not enough liquidity to open")
+    expect(page.get_by_test_id("opening-auction-sub-status").first).to_have_text(
+        "Opening auction: Not enough liquidity to open"
+    )
     print(page.get_by_test_id("opening-auction-sub-status").inner_text)
     vega.submit_liquidity(
         key_name=MM_WALLET.name,

--- a/tests/market/test_market_selector.py
+++ b/tests/market/test_market_selector.py
@@ -1,65 +1,88 @@
 import pytest
 from playwright.sync_api import expect, Page
 
-@pytest.mark.usefixtures("continuous_market","auth")
+
+@pytest.mark.usefixtures("page", "continuous_market", "auth")
 def test_market_selector(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
-    expect(page.get_by_test_id('market-selector')).not_to_be_visible()
-    page.get_by_test_id('header-title').click()
-    #6001-MARK-066
-    expect(page.get_by_test_id('market-selector')).to_be_visible()
+    expect(page.get_by_test_id("market-selector")).not_to_be_visible()
+    page.get_by_test_id("header-title").click()
+    # 6001-MARK-066
+    expect(page.get_by_test_id("market-selector")).to_be_visible()
 
-    #6001-MARK-021
-    #6001-MARK-022
-    #6001-MARK-024
-    #6001-MARK-025
+    # 6001-MARK-021
+    # 6001-MARK-022
+    # 6001-MARK-024
+    # 6001-MARK-025
     btc_market = page.locator('[data-testid="market-selector-list"] a')
-    expect(btc_market.locator('h3')).to_have_text('BTC:DAI_2023 Futr')
-    expect(btc_market.locator('[data-testid="market-selector-volume"]')).to_have_text('0.00')
-    expect(btc_market.locator('[data-testid="market-selector-price"]')).to_have_text('107.50 tDAI')
-    expect(btc_market.locator('span.rounded-md.leading-none')).to_be_visible()
-    expect(btc_market.locator('span.rounded-md.leading-none')).to_have_text('Futr')
+    expect(btc_market.locator("h3")).to_have_text("BTC:DAI_2023 Futr")
+    expect(btc_market.locator('[data-testid="market-selector-volume"]')).to_have_text(
+        "0.00"
+    )
+    expect(btc_market.locator('[data-testid="market-selector-price"]')).to_have_text(
+        "107.50 tDAI"
+    )
+    expect(btc_market.locator("span.rounded-md.leading-none")).to_be_visible()
+    expect(btc_market.locator("span.rounded-md.leading-none")).to_have_text("Futr")
     expect(btc_market.locator('[data-testid="sparkline-svg"]')).not_to_be_visible
 
-   
-@pytest.mark.usefixtures("continuous_market", "simple_market", "auth")
-@pytest.mark.parametrize("simple_market", [{"custom_market_name": "APPL.MF21", "custom_asset_name": "tUSDC", "custom_asset_symbol": "tUSDC"}], indirect=True)
-def test_market_selector_filter(continuous_market,  page: Page):
-    page.goto(f"/#/markets/{continuous_market}")
-    page.get_by_test_id('header-title').click()
-    #6001-MARK-027
 
-    page.get_by_test_id('product-Spot').click()
-    expect(page.get_by_test_id("market-selector-list")).to_contain_text('Spot markets coming soon.')
-    page.get_by_test_id('product-Perpetual').click()
-    expect(page.get_by_test_id("market-selector-list")).to_contain_text('Perpetual markets coming soon.')
-    page.get_by_test_id('product-Future').click()
+@pytest.mark.usefixtures("page", "continuous_market", "simple_market", "auth")
+@pytest.mark.parametrize(
+    "simple_market",
+    [
+        {
+            "custom_market_name": "APPL.MF21",
+            "custom_asset_name": "tUSDC",
+            "custom_asset_symbol": "tUSDC",
+        }
+    ],
+    indirect=True,
+)
+def test_market_selector_filter(continuous_market, page: Page):
+    page.goto(f"/#/markets/{continuous_market}")
+    page.get_by_test_id("header-title").click()
+    # 6001-MARK-027
+
+    page.get_by_test_id("product-Spot").click()
+    expect(page.get_by_test_id("market-selector-list")).to_contain_text(
+        "Spot markets coming soon."
+    )
+    page.get_by_test_id("product-Perpetual").click()
+    expect(page.get_by_test_id("market-selector-list")).to_contain_text(
+        "Perpetual markets coming soon."
+    )
+    page.get_by_test_id("product-Future").click()
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(2)
 
-    #6001-MARK-029
-    page.get_by_test_id("search-term").fill('btc')
+    # 6001-MARK-029
+    page.get_by_test_id("search-term").fill("btc")
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(1)
-    expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text('BTC:DAI_2023 107.50 tDAI0.00')
+    expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text(
+        "BTC:DAI_2023 107.50 tDAI0.00"
+    )
 
     page.get_by_test_id("search-term").clear()
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(2)
 
-    #6001-MARK-030
-    #6001-MARK-031
-    #6001-MARK-032
-    #6001-MARK-033
-    page.get_by_test_id('sort-trigger').click()
-    
-    expect(page.get_by_test_id('sort-item-Gained')).to_have_text('Top gaining')
-    expect(page.get_by_test_id('sort-item-Gained')).to_be_visible()
-    expect(page.get_by_test_id('sort-item-Lost')).to_have_text('Top losing')
-    expect(page.get_by_test_id('sort-item-Lost')).to_be_visible()
-    expect(page.get_by_test_id('sort-item-New')).to_have_text('New markets')
-    expect(page.get_by_test_id('sort-item-New')).to_be_visible()
+    # 6001-MARK-030
+    # 6001-MARK-031
+    # 6001-MARK-032
+    # 6001-MARK-033
+    page.get_by_test_id("sort-trigger").click()
 
-    #6001-MARK-028
-    page.get_by_test_id('sort-trigger').click(force=True)
-    page.get_by_test_id('asset-trigger').click()
-    page.get_by_role('menuitemcheckbox').nth(0).get_by_text('tDAI').click()
+    expect(page.get_by_test_id("sort-item-Gained")).to_have_text("Top gaining")
+    expect(page.get_by_test_id("sort-item-Gained")).to_be_visible()
+    expect(page.get_by_test_id("sort-item-Lost")).to_have_text("Top losing")
+    expect(page.get_by_test_id("sort-item-Lost")).to_be_visible()
+    expect(page.get_by_test_id("sort-item-New")).to_have_text("New markets")
+    expect(page.get_by_test_id("sort-item-New")).to_be_visible()
+
+    # 6001-MARK-028
+    page.get_by_test_id("sort-trigger").click(force=True)
+    page.get_by_test_id("asset-trigger").click()
+    page.get_by_role("menuitemcheckbox").nth(0).get_by_text("tDAI").click()
     expect(page.locator('[data-testid="market-selector-list"] a')).to_have_count(1)
-    expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text('BTC:DAI_2023 107.50 tDAI0.00')
+    expect(page.locator('[data-testid="market-selector-list"] a').nth(0)).to_have_text(
+        "BTC:DAI_2023 107.50 tDAI0.00"
+    )

--- a/tests/market_lifecycle/test_market_lifecycle.py
+++ b/tests/market_lifecycle/test_market_lifecycle.py
@@ -17,7 +17,7 @@ TERMINATE_WALLET = WalletConfig("FJMKnwfZdd48C8NqvYrG", "bY3DxwtsCstMIIZdNpKs")
 wallets = [MM_WALLET, MM_WALLET2, TERMINATE_WALLET]
 
 
-@pytest.mark.usefixtures("proposed_market", "risk_accepted")
+@pytest.mark.usefixtures("vega", "page", "proposed_market", "risk_accepted")
 def test_market_lifecycle(proposed_market, vega: VegaService, page: Page):
     trading_mode = page.get_by_test_id("market-trading-mode").get_by_test_id(
         "item-value"

--- a/tests/navigation/test_navigation.py
+++ b/tests/navigation/test_navigation.py
@@ -1,6 +1,21 @@
 import pytest
 from playwright.sync_api import Page, expect, Locator
 
+from conftest import init_page, init_vega
+
+
+@pytest.fixture(scope="module")
+def vega():
+    with init_vega() as vega:
+        yield vega
+
+
+# we can reuse single page instance in all tests
+@pytest.fixture(scope="module")
+def page(vega, browser, request):
+    with init_page(vega, browser, request) as page:
+        yield page
+
 
 @pytest.mark.usefixtures("risk_accepted")
 def test_network_switcher(page: Page):

--- a/tests/order_details/test_order_details.py
+++ b/tests/order_details/test_order_details.py
@@ -5,39 +5,59 @@ from vega_sim.service import VegaService
 from actions.vega import submit_order
 
 order_details = [
-    ('order-market-label', 'Market', 'order-market-value', 'BTC:DAI_2023'),
-    ('order-side-label', 'Side', 'order-side-value', 'Short'),
-    ('order-type-label', 'Type', 'order-type-value', 'Limit'),
-    ('order-price-label', 'Price', 'order-price-value', '101.00'),
-    ('order-size-label', 'Size', 'order-size-value', '-102'),
-    ('order-remaining-label', 'Remaining', 'order-remaining-value', '-2'),
-    ('order-status-label', 'Status', 'order-status-value', 'Active'),
-    ('order-id-label', 'Order ID', 'order-id-value', '^.{10}\u2026.+Copy$', True),
-    ('order-created-label', 'Created', 'order-created-value', '^\d{1,2}/\d{1,2}/\d{4}, \d{1,2}:\d{2}:\d{2} (AM|PM)$', True),
-    ('order-time-in-force-label', 'Time in force', 'order-time-in-force-value', "Good 'til Cancelled (GTC)")
+    ("order-market-label", "Market", "order-market-value", "BTC:DAI_2023"),
+    ("order-side-label", "Side", "order-side-value", "Short"),
+    ("order-type-label", "Type", "order-type-value", "Limit"),
+    ("order-price-label", "Price", "order-price-value", "101.00"),
+    ("order-size-label", "Size", "order-size-value", "-102"),
+    ("order-remaining-label", "Remaining", "order-remaining-value", "-2"),
+    ("order-status-label", "Status", "order-status-value", "Active"),
+    ("order-id-label", "Order ID", "order-id-value", "^.{10}\u2026.+Copy$", True),
+    (
+        "order-created-label",
+        "Created",
+        "order-created-value",
+        "^\d{1,2}/\d{1,2}/\d{4}, \d{1,2}:\d{2}:\d{2} (AM|PM)$",
+        True,
+    ),
+    (
+        "order-time-in-force-label",
+        "Time in force",
+        "order-time-in-force-value",
+        "Good 'til Cancelled (GTC)",
+    ),
 ]
+
 
 def verify_order_label(page: Page, test_id: str, expected_text: str):
     element = page.get_by_test_id(test_id)
     expect(element).to_be_visible()
     expect(element).to_have_text(expected_text)
 
-def verify_order_value(page: Page, test_id: str, expected_text: str, is_regex: bool = False):
+
+def verify_order_value(
+    page: Page, test_id: str, expected_text: str, is_regex: bool = False
+):
     element = page.get_by_test_id(test_id)
     expect(element).to_be_visible()
     if is_regex:
         actual_text = element.text_content()
-        assert re.match(expected_text, actual_text), f"Expected {expected_text}, but got {actual_text}"
+        assert re.match(
+            expected_text, actual_text
+        ), f"Expected {expected_text}, but got {actual_text}"
     else:
         expect(element).to_have_text(expected_text)
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_order_details_are_correctly_displayed(continuous_market, vega: VegaService, page: Page):
+
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_order_details_are_correctly_displayed(
+    continuous_market, vega: VegaService, page: Page
+):
     page.goto(f"/#/markets/{continuous_market}")
-    submit_order(vega, "Key 1", vega.all_markets()[0].id, "SIDE_SELL", 102, 101,2, 1)
+    submit_order(vega, "Key 1", vega.all_markets()[0].id, "SIDE_SELL", 102, 101, 2, 1)
     page.get_by_test_id("Open").click()
-    page.get_by_test_id('icon-kebab').click()
-    page.get_by_test_id('view-order').click()
+    page.get_by_test_id("icon-kebab").click()
+    page.get_by_test_id("view-order").click()
     for detail in order_details:
         label_id, label_text, value_id, value_text, is_regex = (*detail, False)[:5]
         verify_order_label(page, label_id, label_text)

--- a/tests/order_match/test_order_match.py
+++ b/tests/order_match/test_order_match.py
@@ -77,7 +77,7 @@ def submit_order(vega, wallet_name, market_id, side, volume, price):
     )
 
 
-@pytest.mark.usefixtures("opening_auction_market", "auth")
+@pytest.mark.usefixtures("vega", "page", "opening_auction_market", "auth")
 def test_limit_order_trade_open_order(
     opening_auction_market, vega: VegaService, page: Page
 ):
@@ -107,7 +107,7 @@ def test_limit_order_trade_open_order(
     verify_data_grid(page, "Open", expected_open_order)
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
 def test_limit_order_trade_open_position(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
 
@@ -128,7 +128,7 @@ def test_limit_order_trade_open_position(continuous_market, page: Page):
         "realised_pnl": "0.00",
         "unrealised_pnl": "0.00",
     }
-    
+
     tab = page.get_by_test_id("tab-positions")
     table = tab.locator(".ag-center-cols-container")
 
@@ -137,22 +137,36 @@ def test_limit_order_trade_open_position(continuous_market, page: Page):
 
     market = table.locator("[col-id='marketCode']")
     expect(market.get_by_test_id(primary_id)).to_have_text(position["market_code"])
-    expect(market.get_by_test_id(secondary_id)).to_have_text(position["settlement_asset"] + position["product_type"])
-     
+    expect(market.get_by_test_id(secondary_id)).to_have_text(
+        position["settlement_asset"] + position["product_type"]
+    )
+
     size_and_notional = table.locator("[col-id='openVolume']")
     expect(size_and_notional.get_by_test_id(primary_id)).to_have_text(position["size"])
-    expect(size_and_notional.get_by_test_id(secondary_id)).to_have_text(position["notional"])
+    expect(size_and_notional.get_by_test_id(secondary_id)).to_have_text(
+        position["notional"]
+    )
 
     entry_and_mark = table.locator("[col-id='markPrice']")
-    expect(entry_and_mark.get_by_test_id(primary_id)).to_have_text(position["average_entry_price"])
-    expect(entry_and_mark.get_by_test_id(secondary_id)).to_have_text(position["mark_price"])
+    expect(entry_and_mark.get_by_test_id(primary_id)).to_have_text(
+        position["average_entry_price"]
+    )
+    expect(entry_and_mark.get_by_test_id(secondary_id)).to_have_text(
+        position["mark_price"]
+    )
 
     margin_and_leverage = table.locator("[col-id='margin']")
-    expect(margin_and_leverage.get_by_test_id(primary_id)).to_have_text(position["margin"])
-    expect(margin_and_leverage.get_by_test_id(secondary_id)).to_have_text(position["leverage"])
+    expect(margin_and_leverage.get_by_test_id(primary_id)).to_have_text(
+        position["margin"]
+    )
+    expect(margin_and_leverage.get_by_test_id(secondary_id)).to_have_text(
+        position["leverage"]
+    )
 
     liquidation = table.locator("[col-id='liquidationPrice']")
-    expect(liquidation.get_by_test_id("liquidation-price")).to_have_text(position["liquidation"])
+    expect(liquidation.get_by_test_id("liquidation-price")).to_have_text(
+        position["liquidation"]
+    )
 
     realisedPNL = table.locator("[col-id='realisedPNL']")
     expect(realisedPNL).to_have_text(position["realised_pnl"])
@@ -161,7 +175,7 @@ def test_limit_order_trade_open_position(continuous_market, page: Page):
     expect(unrealisedPNL).to_have_text(position["unrealised_pnl"])
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
 def test_limit_order_trade_order_trade_away(continuous_market, page: Page):
     page.goto(f"/#/markets/{continuous_market}")
     # Assert that the order is no longer on the orderbook

--- a/tests/pnl/test_pnl.py
+++ b/tests/pnl/test_pnl.py
@@ -1,13 +1,8 @@
 import pytest
-import time
-import requests
-import re
 from collections import namedtuple
-from playwright.sync_api import expect, Page
+from playwright.sync_api import Page
 from vega_sim.service import VegaService
 from actions.vega import submit_order
-
-from playwright.sync_api import expect
 
 WalletConfig = namedtuple("WalletConfig", ["name", "passphrase"])
 MM_WALLET = WalletConfig("mm", "pin")
@@ -15,6 +10,7 @@ MM_WALLET2 = WalletConfig("mm2", "pin2")
 TERMINATE_WALLET = WalletConfig("FJMKnwfZdd48C8NqvYrG", "bY3DxwtsCstMIIZdNpKs")
 
 wallets = [MM_WALLET, MM_WALLET2, TERMINATE_WALLET]
+
 
 def wait_for_graphql_response(page, query_name, timeout=5000):
     response_data = {}
@@ -24,10 +20,10 @@ def wait_for_graphql_response(page, query_name, timeout=5000):
             response = request.response()
             if response is not None:
                 json_response = response.json()
-                if json_response and 'data' in json_response:
-                    data = json_response['data']
+                if json_response and "data" in json_response:
+                    data = json_response["data"]
                     if query_name in data:
-                        response_data['data'] = data
+                        response_data["data"] = data
                         route.continue_()
                         return
         route.continue_()
@@ -41,156 +37,163 @@ def wait_for_graphql_response(page, query_name, timeout=5000):
     # Unregister the route handler
     page.unroute("**", handle_response)
 
+
 def check_pnl_color_value(element, expected_color, expected_value):
-    color = element.evaluate('element => getComputedStyle(element).color')
+    color = element.evaluate("element => getComputedStyle(element).color")
     value = element.inner_text()
-    assert color == expected_color, f'Unexpected color: {color}'
-    assert value == expected_value, f'Unexpected value: {value}'
-
-def wait_for_service(url, timeout=60):
-    start_time = time.time()
-    while True:
-        try:
-            response = requests.get(url)
-            if response.status_code == 200:
-                break
-        except Exception:
-            # If the connection attempt fails, wait and try again
-            time.sleep(1)
-            if time.time() - start_time > timeout:
-                raise TimeoutError(f"Timed out waiting for service at {url}")
+    assert color == expected_color, f"Unexpected color: {color}"
+    assert value == expected_value, f"Unexpected value: {value}"
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_pnl_loss_portfolio(continuous_market, vega:VegaService, page: Page):    
-    page.set_viewport_size({"width":1748, "height":977})
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_pnl_loss_portfolio(continuous_market, vega: VegaService, page: Page):
+    page.set_viewport_size({"width": 1748, "height": 977})
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 104.50000)
     page.goto(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_service(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
     page.get_by_role("link", name="Portfolio").click()
-    page.get_by_test_id('Positions').click()
-    wait_for_graphql_response(page, 'EstimatePosition')
-    page.wait_for_selector('[data-testid="tab-positions"] .ag-center-cols-container .ag-row', state='visible')
+    page.get_by_test_id("Positions").click()
+    wait_for_graphql_response(page, "EstimatePosition")
+    page.wait_for_selector(
+        '[data-testid="tab-positions"] .ag-center-cols-container .ag-row',
+        state="visible",
+    )
 
-    row_element = page.query_selector('//div[@role="row" and .//div[@col-id="partyId"]/div/span[text()="Key 1"]]')
-    
+    row_element = page.query_selector(
+        '//div[@role="row" and .//div[@col-id="partyId"]/div/span[text()="Key 1"]]'
+    )
+
     unrealised_pnl = row_element.query_selector('xpath=./div[@col-id="unrealisedPNL"]')
     realised_pnl = row_element.query_selector('xpath=./div[@col-id="realisedPNL"]')
 
-    
-    check_pnl_color_value(realised_pnl, 'rgb(0, 0, 0)', '0.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(236, 0, 60)', '-4.00')
+    check_pnl_color_value(realised_pnl, "rgb(0, 0, 0)", "0.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(236, 0, 60)", "-4.00")
 
     submit_order(vega, "Key 1", continuous_market, "SIDE_SELL", 2, 101.50000)
-    
-    wait_for_graphql_response(page, 'EstimatePosition')
-    check_pnl_color_value(realised_pnl, 'rgb(236, 0, 60)', '-8.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
+
+    wait_for_graphql_response(page, "EstimatePosition")
+    check_pnl_color_value(realised_pnl, "rgb(236, 0, 60)", "-8.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(0, 0, 0)", "0.00")
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_pnl_profit_portfolio(continuous_market, vega:VegaService, page: Page):
-    page.set_viewport_size({"width":1748, "height":977})
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_pnl_profit_portfolio(continuous_market, vega: VegaService, page: Page):
+    page.set_viewport_size({"width": 1748, "height": 977})
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 104.50000)
     page.goto(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_service(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
     page.get_by_role("link", name="Portfolio").click()
-    page.get_by_test_id('Positions').click()
-    wait_for_graphql_response(page, 'EstimatePosition')
-    page.wait_for_selector('[data-testid="tab-positions"] .ag-center-cols-container .ag-row', state='visible')
+    page.get_by_test_id("Positions").click()
+    wait_for_graphql_response(page, "EstimatePosition")
+    page.wait_for_selector(
+        '[data-testid="tab-positions"] .ag-center-cols-container .ag-row',
+        state="visible",
+    )
 
     selector = '//div[@role="row" and .//div[@col-id="partyId"]/div/span[text()="mm"]]'
-    
+
     row_element = page.query_selector(selector)
     unrealised_pnl = row_element.query_selector('xpath=./div[@col-id="unrealisedPNL"]')
     realised_pnl = row_element.query_selector('xpath=./div[@col-id="realisedPNL"]')
 
-    
-    check_pnl_color_value(realised_pnl, 'rgb(0, 0, 0)', '0.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(1, 145, 75)', '4.00')
-    
+    check_pnl_color_value(realised_pnl, "rgb(0, 0, 0)", "0.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(1, 145, 75)", "4.00")
+
     submit_order(vega, "Key 1", continuous_market, "SIDE_SELL", 2, 101.50000)
-    wait_for_graphql_response(page, 'EstimatePosition')
-    check_pnl_color_value(realised_pnl, 'rgb(1, 145, 75)', '8.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
- 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_pnl_neutral_portfolio(continuous_market, vega:VegaService, page: Page):
-    page.set_viewport_size({"width":1748, "height":977})
+    wait_for_graphql_response(page, "EstimatePosition")
+    check_pnl_color_value(realised_pnl, "rgb(1, 145, 75)", "8.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(0, 0, 0)", "0.00")
+
+
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_pnl_neutral_portfolio(continuous_market, vega: VegaService, page: Page):
+    page.set_viewport_size({"width": 1748, "height": 977})
     page.goto(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_service(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
     page.get_by_role("link", name="Portfolio").click()
-    page.get_by_test_id('Positions').click()
-    wait_for_graphql_response(page, 'EstimatePosition')
-    page.wait_for_selector('[data-testid="tab-positions"] .ag-center-cols-container .ag-row', state='visible')
-   
-    row = page.get_by_test_id("tab-positions").locator(".ag-center-cols-container .ag-row").nth(0)
+    page.get_by_test_id("Positions").click()
+    wait_for_graphql_response(page, "EstimatePosition")
+    page.wait_for_selector(
+        '[data-testid="tab-positions"] .ag-center-cols-container .ag-row',
+        state="visible",
+    )
+
+    row = (
+        page.get_by_test_id("tab-positions")
+        .locator(".ag-center-cols-container .ag-row")
+        .nth(0)
+    )
     realised_pnl = row.locator("[col-id='realisedPNL']")
     unrealised_pnl = row.locator("[col-id='unrealisedPNL']")
 
-    check_pnl_color_value(realised_pnl, 'rgb(0, 0, 0)', '0.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
-    
+    check_pnl_color_value(realised_pnl, "rgb(0, 0, 0)", "0.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(0, 0, 0)", "0.00")
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_pnl_loss_trading(continuous_market, vega:VegaService, page: Page):
+
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_pnl_loss_trading(continuous_market, vega: VegaService, page: Page):
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 104.50000)
-    page.set_viewport_size({"width":1748, "height":977})
+    page.set_viewport_size({"width": 1748, "height": 977})
     page.goto(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_service(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_graphql_response(page, 'EstimatePosition')
+    wait_for_graphql_response(page, "EstimatePosition")
 
-    row = page.get_by_test_id("tab-positions").locator(".ag-center-cols-container .ag-row").nth(0)
+    row = (
+        page.get_by_test_id("tab-positions")
+        .locator(".ag-center-cols-container .ag-row")
+        .nth(0)
+    )
     realised_pnl = row.locator("[col-id='realisedPNL']")
     unrealised_pnl = row.locator("[col-id='unrealisedPNL']")
 
-    check_pnl_color_value(realised_pnl, 'rgb(0, 0, 0)', '0.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(236, 0, 60)', '-4.00')
+    check_pnl_color_value(realised_pnl, "rgb(0, 0, 0)", "0.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(236, 0, 60)", "-4.00")
 
     submit_order(vega, "Key 1", continuous_market, "SIDE_SELL", 2, 101.50000)
-    
-    wait_for_graphql_response(page, 'EstimatePosition')
-    check_pnl_color_value(realised_pnl, 'rgb(236, 0, 60)', '-8.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
 
-    
+    wait_for_graphql_response(page, "EstimatePosition")
+    check_pnl_color_value(realised_pnl, "rgb(236, 0, 60)", "-8.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(0, 0, 0)", "0.00")
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_pnl_profit_trading(continuous_market, vega:VegaService, page: Page):
+
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_pnl_profit_trading(continuous_market, vega: VegaService, page: Page):
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 104.50000)
-    page.set_viewport_size({"width":1748, "height":977})
+    page.set_viewport_size({"width": 1748, "height": 977})
 
     page.goto(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_service(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    page.get_by_test_id('manage-vega-wallet').click()
-    page.get_by_role('menuitemradio').nth(1).click(position={ "x": 10, "y": 10})
+    page.get_by_test_id("manage-vega-wallet").click()
+    page.get_by_role("menuitemradio").nth(1).click(position={"x": 10, "y": 10})
     element_locator = page.get_by_test_id("manage-vega-wallet")
     element_locator.click(force=True)
-    wait_for_graphql_response(page, 'EstimatePosition')
+    wait_for_graphql_response(page, "EstimatePosition")
 
-    row = page.get_by_test_id("tab-positions").locator(".ag-center-cols-container .ag-row").nth(0)
+    row = (
+        page.get_by_test_id("tab-positions")
+        .locator(".ag-center-cols-container .ag-row")
+        .nth(0)
+    )
     realised_pnl = row.locator("[col-id='realisedPNL']")
     unrealised_pnl = row.locator("[col-id='unrealisedPNL']")
 
-    check_pnl_color_value(realised_pnl, 'rgb(0, 0, 0)', '0.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(1, 145, 75)', '4.00')
+    check_pnl_color_value(realised_pnl, "rgb(0, 0, 0)", "0.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(1, 145, 75)", "4.00")
 
     submit_order(vega, "Key 1", continuous_market, "SIDE_SELL", 2, 101.50000)
-    wait_for_graphql_response(page, 'EstimatePosition')
-    check_pnl_color_value(realised_pnl, 'rgb(1, 145, 75)', '8.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
+    wait_for_graphql_response(page, "EstimatePosition")
+    check_pnl_color_value(realised_pnl, "rgb(1, 145, 75)", "8.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(0, 0, 0)", "0.00")
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_pnl_neutral_trading(continuous_market, vega:VegaService, page: Page):
-    page.set_viewport_size({"width":1748, "height":977})
+
+@pytest.mark.usefixtures("vega", "page", "continuous_market", "auth")
+def test_pnl_neutral_trading(continuous_market, vega: VegaService, page: Page):
+    page.set_viewport_size({"width": 1748, "height": 977})
     page.goto(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_service(f"http://localhost:{vega.console_port}/#/markets/{continuous_market}")
-    wait_for_graphql_response(page, 'EstimatePosition')
-    
-    row = page.get_by_test_id("tab-positions").locator(".ag-center-cols-container .ag-row").nth(0)
+    wait_for_graphql_response(page, "EstimatePosition")
+
+    row = (
+        page.get_by_test_id("tab-positions")
+        .locator(".ag-center-cols-container .ag-row")
+        .nth(0)
+    )
     realised_pnl = row.locator("[col-id='realisedPNL']")
     unrealised_pnl = row.locator("[col-id='unrealisedPNL']")
 
-    check_pnl_color_value(realised_pnl, 'rgb(0, 0, 0)', '0.00')
-    check_pnl_color_value(unrealised_pnl, 'rgb(0, 0, 0)', '0.00')
-        
+    check_pnl_color_value(realised_pnl, "rgb(0, 0, 0)", "0.00")
+    check_pnl_color_value(unrealised_pnl, "rgb(0, 0, 0)", "0.00")

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,8 +1,15 @@
 import pytest
 from playwright.sync_api import expect, Page
+from conftest import init_vega
 
 
-@pytest.mark.usefixtures("risk_accepted")
+@pytest.fixture(scope="module")
+def vega():
+    with init_vega() as vega:
+        yield vega
+
+
+@pytest.mark.usefixtures("page", "risk_accepted")
 def test_share_usage_data(page: Page):
     page.goto("/")
     page.get_by_test_id("Settings").click()
@@ -31,7 +38,7 @@ ICON_TO_TOAST = {
 }
 
 
-@pytest.mark.usefixtures("risk_accepted")
+@pytest.mark.usefixtures("page", "risk_accepted")
 def test_toast_positions(page: Page):
     page.goto("/")
     page.get_by_test_id("Settings").click()
@@ -42,7 +49,7 @@ def test_toast_positions(page: Page):
         expect(page.locator(f"[{toast_selector}]")).to_be_visible()
 
 
-@pytest.mark.usefixtures("risk_accepted")
+@pytest.mark.usefixtures("page", "risk_accepted")
 def test_dark_mode(page: Page):
     page.goto("/")
     page.get_by_test_id("Settings").click()

--- a/tests/successor_market/test_succession_line.py
+++ b/tests/successor_market/test_succession_line.py
@@ -1,43 +1,37 @@
 import pytest
 from playwright.sync_api import Page, expect
 from vega_sim.service import VegaService
-from fixtures.market import (
-    setup_continuous_market,
-    setup_simple_market,
-    setup_simple_successor_market
-)
+from fixtures.market import setup_simple_market, setup_simple_successor_market
 
-@pytest.mark.usefixtures("risk_accepted")
-def test_succession_line(vega: VegaService, page: Page):
-    market_id = setup_continuous_market(vega)
+
+@pytest.fixture
+@pytest.mark.usefixtures("vega")
+def successor_market(vega: VegaService):
     parent_market_id = setup_simple_market(vega)
     tdai_id = vega.find_asset_id(symbol="tDAI")
-    market_id2 = setup_simple_successor_market(vega, parent_market_id, tdai_id, "successor_market")
-    vega.settle_market(
-        settlement_key="FJMKnwfZdd48C8NqvYrG",
-        settlement_price=110,
-        market_id=market_id,
+    return setup_simple_successor_market(
+        vega, parent_market_id, tdai_id, "successor_market"
     )
-    page.goto(f"/#/markets/{market_id2}")
-    page.get_by_test_id('Info').click()
-    page.get_by_text('Succession line').click()
 
-    expect(page.get_by_test_id('succession-line-item').first).to_contain_text('BTC:DAI_2023BTC:DAI_2023')
-    expect(page.get_by_test_id('succession-line-item').first.get_by_role('link')).to_be_attached
-    expect(page.get_by_test_id('succession-line-item').last).to_contain_text('successor_marketsuccessor_market')
-    expect(page.get_by_test_id('succession-line-item').last.get_by_role('link')).to_be_attached
-    expect(page.get_by_test_id('succession-line-item').last.get_by_test_id('icon-bullet')).to_be_visible
 
-@pytest.mark.usefixtures("risk_accepted", "auth")
-def test_test(vega: VegaService, page: Page):
-    market_id = setup_continuous_market(vega)
+@pytest.mark.usefixtures("page", "risk_accepted")
+def test_succession_line(page: Page, successor_market):
+    page.goto(f"/#/markets/{successor_market}")
+    page.get_by_test_id("Info").click()
+    page.get_by_text("Succession line").click()
 
-    vega.settle_market(
-        settlement_key="FJMKnwfZdd48C8NqvYrG",
-        settlement_price=110,
-        market_id=market_id,
+    expect(page.get_by_test_id("succession-line-item").first).to_contain_text(
+        "BTC:DAI_2023BTC:DAI_2023"
     )
-    vega.forward("10s")
-    vega.wait_for_total_catchup()
-    page.goto(f"/#/markets/{market_id}")
-   
+    expect(
+        page.get_by_test_id("succession-line-item").first.get_by_role("link")
+    ).to_be_attached
+    expect(page.get_by_test_id("succession-line-item").last).to_contain_text(
+        "successor_marketsuccessor_market"
+    )
+    expect(
+        page.get_by_test_id("succession-line-item").last.get_by_role("link")
+    ).to_be_attached
+    expect(
+        page.get_by_test_id("succession-line-item").last.get_by_test_id("icon-bullet")
+    ).to_be_visible

--- a/tests/trade_history/test_trade_history.py
+++ b/tests/trade_history/test_trade_history.py
@@ -2,6 +2,13 @@ import pytest
 import re
 from playwright.sync_api import expect
 from actions.vega import submit_order
+from conftest import init_vega
+
+
+@pytest.fixture(scope="module")
+def vega():
+    with init_vega() as vega:
+        yield vega
 
 
 # Could be turned into a helper function in the future.
@@ -62,7 +69,7 @@ def wait_for_graphql_response(page, query_name, timeout=5000):
     page.unroute("**", handle_response)
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
+@pytest.mark.usefixtures("page", "continuous_market", "auth")
 def test_limit_order_new_trade_top_of_list(continuous_market, vega, page):
     submit_order(vega, "Key 1", continuous_market, "SIDE_BUY", 1, 110)
     page.goto(f"/#/markets/{continuous_market}")
@@ -85,8 +92,8 @@ def test_limit_order_new_trade_top_of_list(continuous_market, vega, page):
     verify_data_grid(page, "Trades", expected_trade)
 
 
-@pytest.mark.usefixtures("continuous_market", "auth")
-def test_price_copied_to_deal_ticket(continuous_market, vega, page):
+@pytest.mark.usefixtures("page", "continuous_market", "auth")
+def test_price_copied_to_deal_ticket(continuous_market, page):
     page.goto(f"/#/markets/{continuous_market}")
     page.get_by_test_id("Trades").click()
     wait_for_graphql_response(page, "Trades")

--- a/tests/trade_match/test_trade_match.py
+++ b/tests/trade_match/test_trade_match.py
@@ -5,8 +5,7 @@ from vega_sim.service import VegaService
 from actions.vega import submit_multiple_orders
 
 
-
-@pytest.mark.usefixtures("opening_auction_market", "auth")
+@pytest.mark.usefixtures("page", "vega", "opening_auction_market", "auth")
 def test_trade_match_table(opening_auction_market: str, vega: VegaService, page: Page):
     row_locator = ".ag-center-cols-container .ag-row"
 
@@ -56,37 +55,50 @@ def test_trade_match_table(opening_auction_market: str, vega: VegaService, page:
         "unrealised_pnl": "0.00",
     }
     page.goto(f"/#/markets/{opening_auction_market}")
-     # 7004-POSI-001
+    # 7004-POSI-001
     # 7004-POSI-002
     primary_id = "stack-cell-primary"
-    secondary_id = "stack-cell-secondary" 
+    secondary_id = "stack-cell-secondary"
 
     tab = page.get_by_test_id("tab-positions")
     table = tab.locator(".ag-center-cols-container")
 
     market = table.locator("[col-id='marketCode']")
     expect(market.get_by_test_id(primary_id)).to_have_text(position["market_code"])
-    expect(market.get_by_test_id(secondary_id)).to_have_text(position["settlement_asset"] + position["product_type"])
+    expect(market.get_by_test_id(secondary_id)).to_have_text(
+        position["settlement_asset"] + position["product_type"]
+    )
     size_and_notional = table.locator("[col-id='openVolume']")
     expect(size_and_notional.get_by_test_id(primary_id)).to_have_text(position["size"])
-    expect(size_and_notional.get_by_test_id(secondary_id)).to_have_text(position["notional"])
+    expect(size_and_notional.get_by_test_id(secondary_id)).to_have_text(
+        position["notional"]
+    )
 
     entry_and_mark = table.locator("[col-id='markPrice']")
-    expect(entry_and_mark.get_by_test_id(primary_id)).to_have_text(position["average_entry_price"])
-    expect(entry_and_mark.get_by_test_id(secondary_id)).to_have_text(position["mark_price"])
+    expect(entry_and_mark.get_by_test_id(primary_id)).to_have_text(
+        position["average_entry_price"]
+    )
+    expect(entry_and_mark.get_by_test_id(secondary_id)).to_have_text(
+        position["mark_price"]
+    )
 
     margin_and_leverage = table.locator("[col-id='margin']")
-    expect(margin_and_leverage.get_by_test_id(primary_id)).to_have_text(position["margin"])
-    expect(margin_and_leverage.get_by_test_id(secondary_id)).to_have_text(position["leverage"])
+    expect(margin_and_leverage.get_by_test_id(primary_id)).to_have_text(
+        position["margin"]
+    )
+    expect(margin_and_leverage.get_by_test_id(secondary_id)).to_have_text(
+        position["leverage"]
+    )
     liquidation = table.locator("[col-id='liquidationPrice']")
-    expect(liquidation.get_by_test_id("liquidation-price")).to_have_text(position["liquidation"])
+    expect(liquidation.get_by_test_id("liquidation-price")).to_have_text(
+        position["liquidation"]
+    )
 
     realisedPNL = table.locator("[col-id='realisedPNL']")
     expect(realisedPNL).to_have_text(position["realised_pnl"])
 
     unrealisedPNL = table.locator("[col-id='unrealisedPNL']")
     expect(unrealisedPNL).to_have_text(position["unrealised_pnl"])
-    
 
     # Open
     page.get_by_test_id("Open").click()


### PR DESCRIPTION
Closes #53 

Contextmanager was used to create `init_vega` and `init_page`. Those can be used to create `vega` and `page` fixtures. Autouse has been disabled, to allow scope change. There are default `vega` and `page` with function scope available in conftest to use in tests (so they are created before separate test function and destroyed after). In order to use single market-sim instance in one test file, separate fixture should be created in the file with scope = module. We may want to review existing tests to see if module or class scoped vega fixture can be used.
Added new option to  run - `--dist loadfile` - it makes sure, that only single worker can be assigned to test file, to avoid creation of additional vega instances. 