### PR TITLE
test(trading): test_markets_all added

### DIFF
--- a/fixtures/market.py
+++ b/fixtures/market.py
@@ -17,7 +17,13 @@ mint_amount: float = 10e5
 market_name = "BTC:DAI_2023"
 
 
-def setup_simple_market(vega: VegaService, approve_proposal=True, custom_market_name=market_name, custom_asset_name="tDAI", custom_asset_symbol="tDAI"):
+def setup_simple_market(
+    vega: VegaService,
+    approve_proposal=True,
+    custom_market_name=market_name,
+    custom_asset_name="tDAI",
+    custom_asset_symbol="tDAI",
+):
     for wallet in wallets:
         vega.create_key(wallet.name)
 
@@ -66,7 +72,7 @@ def setup_simple_market(vega: VegaService, approve_proposal=True, custom_market_
     vega.wait_for_total_catchup()
 
     market_id = vega.create_simple_market(
-        custom_market_name, 
+        custom_market_name,
         proposal_key=MM_WALLET.name,
         settlement_asset_id=tdai_id,
         termination_key=TERMINATE_WALLET.name,
@@ -81,8 +87,10 @@ def setup_simple_market(vega: VegaService, approve_proposal=True, custom_market_
 
     return market_id
 
-def setup_simple_successor_market(vega: VegaService, parent_market_id, tdai_id, market_name, approve_proposal=True):
-    
+
+def setup_simple_successor_market(
+    vega: VegaService, parent_market_id, tdai_id, market_name, approve_proposal=True
+):
     market_id = vega.create_simple_market(
         market_name,
         proposal_key=MM_WALLET.name,
@@ -92,7 +100,7 @@ def setup_simple_successor_market(vega: VegaService, parent_market_id, tdai_id, 
         approve_proposal=approve_proposal,
         forward_time_to_enactment=approve_proposal,
         parent_market_id=parent_market_id,
-        parent_market_insurance_pool_fraction=0.5
+        parent_market_insurance_pool_fraction=0.5,
     )
 
     vega.forward("10s")
@@ -101,9 +109,10 @@ def setup_simple_successor_market(vega: VegaService, parent_market_id, tdai_id, 
 
     return market_id
 
-def setup_opening_auction_market(vega: VegaService, market_id: str = None):
+
+def setup_opening_auction_market(vega: VegaService, market_id: str = None, **kwargs):
     if market_id is None or market_id not in vega.all_markets():
-        market_id = setup_simple_market(vega)
+        market_id = setup_simple_market(vega, **kwargs)
 
     submit_liquidity(vega, MM_WALLET.name, market_id)
     submit_multiple_orders(
@@ -119,9 +128,9 @@ def setup_opening_auction_market(vega: VegaService, market_id: str = None):
     return market_id
 
 
-def setup_continuous_market(vega: VegaService, market_id: str = None):
+def setup_continuous_market(vega: VegaService, market_id: str = None, **kwargs):
     if market_id is None or market_id not in vega.all_markets():
-        market_id = setup_opening_auction_market(vega)
+        market_id = setup_opening_auction_market(vega, **kwargs)
 
     submit_order(vega, "Key 1", market_id, "SIDE_BUY", 1, 110)
     vega.forward("10s")

--- a/poetry.lock
+++ b/poetry.lock
@@ -599,18 +599,18 @@ profile = ["pytest-profiling", "snakeviz"]
 type = "git"
 url = "https://github.com/vegaprotocol/vega-market-sim.git"
 reference = "HEAD"
-resolved_reference = "27770282baddb56fd04df79c7111b25c19c4142e"
+resolved_reference = "303fe0a6866053be61ecf7e83bb9245fb5ea91b9"
 
 [[package]]
 name = "websocket-client"
-version = "1.6.1"
+version = "1.6.2"
 description = "WebSocket client for Python with low level API options"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.extras]
-docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+docs = ["Sphinx (>=6.0)", "sphinx-rtd-theme (>=1.1.0)"]
 optional = ["python-socks", "wsaccel"]
 test = ["websockets"]
 
@@ -1218,8 +1218,8 @@ urllib3 = [
 ]
 vega-sim = []
 websocket-client = [
-    {file = "websocket-client-1.6.1.tar.gz", hash = "sha256:c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd"},
-    {file = "websocket_client-1.6.1-py3-none-any.whl", hash = "sha256:f1f9f2ad5291f0225a49efad77abf9e700b6fef553900623060dad6e26503b9d"},
+    {file = "websocket-client-1.6.2.tar.gz", hash = "sha256:53e95c826bf800c4c465f50093a8c4ff091c7327023b10bfaff40cf1ef170eaa"},
+    {file = "websocket_client-1.6.2-py3-none-any.whl", hash = "sha256:ce54f419dfae71f4bdba69ebe65bf7f0a93fe71bc009ad3a010aacc3eebad537"},
 ]
 wrapt = [
     {file = "wrapt-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1"},

--- a/tests/market/test_markets_all.py
+++ b/tests/market/test_markets_all.py
@@ -1,0 +1,184 @@
+import pytest
+from playwright.sync_api import Page, expect
+from fixtures.market import setup_continuous_market
+
+from conftest import init_vega
+
+market_names = ["ETHBTC.QM21", "BTCUSD.MF21", "SOLUSD", "AAPL.MF21"]
+
+
+@pytest.fixture(scope="class")
+def vega():
+    with init_vega() as vega:
+        yield vega
+
+
+@pytest.fixture(scope="class")
+def create_markets(vega):
+    for market_name in market_names:
+        setup_continuous_market(vega, custom_market_name=market_name)
+
+
+class TestAllMarkets:
+    @pytest.mark.usefixtures("risk_accepted")
+    def test_table_headers(self, page: Page, create_markets):
+        page.goto(f"/#/markets/all")
+        headers = [
+            "Market",
+            "Description",
+            "Trading mode",
+            "Status",
+            "Successor market",
+            "Best bid",
+            "Best offer",
+            "Mark price",
+            "Settlement asset",
+            "",
+        ]
+
+        page.wait_for_selector('[data-testid="tab-open-markets"]', state="visible")
+        page_headers = (
+            page.get_by_test_id("tab-open-markets")
+            .locator(".ag-header-cell-text")
+            .all()
+        )
+        for i, header in enumerate(headers):
+            expect(page_headers[i]).to_have_text(header)
+
+    @pytest.mark.usefixtures("risk_accepted")
+    def test_markets_tab(self, page: Page, create_markets):
+        page.goto(f"/#/markets/all")
+        expect(page.get_by_test_id("Open markets")).to_have_attribute(
+            "data-state", "active"
+        )
+        expect(page.get_by_test_id("Proposed markets")).to_have_attribute(
+            "data-state", "inactive"
+        )
+        expect(page.get_by_test_id("Closed markets")).to_have_attribute(
+            "data-state", "inactive"
+        )
+
+    @pytest.mark.usefixtures("risk_accepted")
+    def test_markets_content(self, page: Page, create_markets):
+        page.goto(f"/#/markets/all")
+        row_selector = page.locator(
+            '[data-testid="tab-open-markets"] .ag-center-cols-container .ag-row'
+        ).first
+        instrument_code_locator = (
+            '[col-id="tradableInstrument.instrument.code"] [data-testid="market-code"]'
+        )
+
+        # 6001-MARK-035
+        expect(row_selector.locator(instrument_code_locator)).to_have_text(
+            "ETHBTC.QM21"
+        )
+
+        # 6001-MARK-073
+        expect(row_selector.locator('[title="Future"]')).to_have_text("Futr")
+
+        #  6001-MARK-036
+        expect(
+            row_selector.locator('[col-id="tradableInstrument.instrument.name"]')
+        ).to_have_text("ETHBTC.QM21")
+
+        #  6001-MARK-037
+        expect(row_selector.locator('[col-id="tradingMode"]')).to_have_text(
+            "Continuous"
+        )
+
+        #  6001-MARK-038
+        expect(row_selector.locator('[col-id="state"]')).to_have_text("Active")
+
+        # successor market
+        expect(row_selector.locator('[col-id="successorMarketID"]')).to_have_text("-")
+
+        #  6001-MARK-039
+        expect(row_selector.locator('[col-id="data.bestBidPrice"]')).to_have_text(
+            "101.50"
+        )
+
+        #  6001-MARK-040
+        expect(row_selector.locator('[col-id="data.bestOfferPrice"]')).to_have_text(
+            "103.50"
+        )
+
+        #  6001-MARK-041
+        expect(row_selector.locator('[col-id="data.markPrice"]')).to_have_text("107.50")
+
+        #  6001-MARK-042
+        expect(
+            row_selector.locator(
+                '[col-id="tradableInstrument.instrument.product.settlementAsset.symbol"]'
+            )
+        ).to_have_text("tDAI")
+
+        # 6001-MARK-043
+        row_selector.locator(
+            '[col-id="tradableInstrument.instrument.product.settlementAsset.symbol"] button'
+        ).click()
+        expect(page.get_by_test_id("dialog-title")).to_have_text("Asset details - tDAI")
+        page.get_by_test_id("close-asset-details-dialog").click()
+
+    @pytest.mark.usefixtures("risk_accepted")
+    def test_market_actions(self, page: Page, create_markets):
+        # 6001-MARK-044
+        # 6001-MARK-045
+        # 6001-MARK-046
+        # 6001-MARK-047
+        page.goto(f"/#/markets/all")
+        page.locator(
+            '.ag-pinned-right-cols-container [col-id="market-actions"]'
+        ).first.locator("button").click()
+
+        actions = [
+            "Copy Market ID",
+            "View on Explorer",
+            "View settlement asset details",
+        ]
+        action_elements = (
+            page.get_by_test_id("market-actions-content").get_by_role("menuitem").all()
+        )
+
+        for i, action in enumerate(actions):
+            expect(action_elements[i]).to_have_text(action)
+
+    @pytest.mark.usefixtures("risk_accepted")
+    def test_sort_markets(self, page: Page, create_markets):
+        # 6001-MARK-064
+
+        page.goto(f"/#/markets/all")
+        sorted_market_names = [
+            "AAPL.MF21",
+            "BTCUSD.MF21",
+            "ETHBTC.QM21",
+            "SOLUSD",
+        ]
+        page.locator(
+            '.ag-header-row [col-id="tradableInstrument.instrument.code"]'
+        ).click()
+        for i, market_name in enumerate(sorted_market_names):
+            expect(
+                page.locator(f'[row-index="{i}"] [data-testid=market-code]')
+            ).to_have_text(market_name)
+
+    @pytest.mark.usefixtures("risk_accepted")
+    def test_drag_and_drop_column(self, page: Page, create_markets):
+        # 6001-MARK-065
+        page.goto(f"/#/markets/all")
+        col_instrument_code = (
+            '.ag-header-row [col-id="tradableInstrument.instrument.code"]'
+        )
+
+        page.locator(col_instrument_code).drag_to(
+            page.locator('.ag-header-row [col-id="data.bestBidPrice"]')
+        )
+        expect(page.locator(col_instrument_code)).to_have_attribute(
+            "aria-colindex", "6"
+        )
+
+
+class TestAllMarketsNoMarkets:
+    @pytest.mark.usefixtures("risk_accepted")
+    def test_no_markets(self, page: Page):
+        page.goto(f"/#/markets/all")
+        expect(page.locator(".ag-overlay-wrapper")).to_have_text("No markets")


### PR DESCRIPTION
Closes #83 

Tests moved from `frontend-monorepo` - `market-all.cy.ts`.

Tests are wrapped into two classes in order to cover two situations - there are markets created, and there are no markets in the network. That's why fixtures have scope `class` and `self` is needed as first argument of all tests.