### PR TITLE
chore(trading): create traces folder

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -89,8 +89,14 @@ def init_page(vega: VegaServiceNull, browser: Browser, request: pytest.FixtureRe
                 page.add_init_script(script=window_env)
                 yield page
             finally:
-                trace_path = os.path.join("traces", request.node.name + "trace.zip")
-                context.tracing.stop(path=trace_path)
+                if not os.path.exists("traces"):
+                    os.makedirs("traces")
+
+                try:
+                    trace_path = os.path.join("traces", request.node.name + "trace.zip")
+                    context.tracing.stop(path=trace_path)
+                except Exception as e:
+                    print(f"Failed to save trace: {e}")
 
 
 # default vega & page fixtures with function scope (refreshed at each test) that can be used in tests


### PR DESCRIPTION
Currently traces aren't created on runes against the monorepo with the error:

`Warning: No files were found with the provided path: ./traces/. No artifacts will be uploaded.`

This is to to create the traces folder for traces to be saved to.