### PR TITLE
chore: run console-test using 4-cores github-runner

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,12 +17,20 @@ jobs:
       - uses: actions/checkout@v3
       #----------------------------------------------
       #  -----  install dependencies  -----
-      #----------------------------------------------\
+      #----------------------------------------------
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          cache: "poetry"
           python-version: "3.10"
+    #----------------------------------------------
+    #  -----  install & configure poetry  -----
+    #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: console-test/.venv
       
       - name: Install dependencies
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     timeout-minutes: 30
-    runs-on: console-test
+    runs-on: 8-cores
     steps:
       - uses: actions/checkout@v3
       #----------------------------------------------
@@ -56,7 +56,7 @@ jobs:
       #  ----- run tests. -----
       #----------------------------------------------
       - name: Run tests
-        run: poetry run pytest -v -s --numprocesses 2 --dist loadfile --durations=20
+        run: poetry run pytest -v -s --numprocesses 4 --dist loadfile --durations=20
       #----------------------------------------------
       #  -----  upload traces  -----
       #----------------------------------------------

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,9 +17,16 @@ jobs:
       - uses: actions/checkout@v3
       #----------------------------------------------
       #  -----  install dependencies  -----
-      #----------------------------------------------
+      #----------------------------------------------\
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          cache: "poetry"
+          python-version: 3.10
+      
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
+
       #----------------------------------------------
       #  -----  find vega binaries path  -----
       #----------------------------------------------

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,7 +71,7 @@ jobs:
       #  ----- run tests. -----
       #----------------------------------------------
       - name: Run tests
-        run: poetry run pytest -v -s --numprocesses 4 --dist loadfile --durations=20
+        run: poetry run pytest -v -s --numprocesses 6 --dist loadfile --durations=20
       #----------------------------------------------
       #  -----  upload traces  -----
       #----------------------------------------------

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     timeout-minutes: 30
-    runs-on: 8-cores
+    runs-on: 4-cores
     steps:
       - uses: actions/checkout@v3
       #----------------------------------------------
@@ -71,7 +71,7 @@ jobs:
       #  ----- run tests. -----
       #----------------------------------------------
       - name: Run tests
-        run: poetry run pytest -v -s --numprocesses 8 --dist loadfile --durations=20
+        run: poetry run pytest -v -s --numprocesses 4 --dist loadfile --durations=20
       #----------------------------------------------
       #  -----  upload traces  -----
       #----------------------------------------------

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,7 +71,7 @@ jobs:
       #  ----- run tests. -----
       #----------------------------------------------
       - name: Run tests
-        run: poetry run pytest -v -s --numprocesses 6 --dist loadfile --durations=20
+        run: poetry run pytest -v -s --numprocesses 8 --dist loadfile --durations=20
       #----------------------------------------------
       #  -----  upload traces  -----
       #----------------------------------------------

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: "poetry"
-          python-version: 3.10
+          python-version: "3.10"
       
       - name: Install dependencies
         run: poetry install --no-interaction --no-root


### PR DESCRIPTION
Our tests are much more stable and github-runner provide much better performance currently. We may consider switching again to self-hosted runners if our issues with runners performance are resolved.